### PR TITLE
Add active-high (always) VBLANK pin

### DIFF
--- a/rtl/icebreaker/xosera_iceb.sv
+++ b/rtl/icebreaker/xosera_iceb.sv
@@ -243,6 +243,9 @@ xosera_main xosera_main(
             .red_o(vga_r),
             .green_o(vga_g),
             .blue_o(vga_b),
+            /* verilator lint_off PINCONNECTEMPTY */
+            .vblank_o(),                    // TODO Should probably have a pin?
+            /* verilator lint_on  PINCONNECTEMPTY */
             .vsync_o(vga_vs),
             .hsync_o(vga_hs),
             .dv_de_o(dv_de),

--- a/rtl/sim/xosera_tb.sv
+++ b/rtl/sim/xosera_tb.sv
@@ -38,6 +38,7 @@ logic reconfig;
 logic [1:0] boot_select;
 
 // bus interface
+logic vblank;
 logic bus_cs_n;
 logic bus_rd_nwr;
 logic bus_bytesel;
@@ -61,6 +62,7 @@ xosera_main xosera(
                 .red_o(red),                    // pixel clock
                 .green_o(green),                // pixel clock
                 .blue_o(blue),                  // pixel clock
+                .vblank_o(vblank),              // Vertical blank indicator
                 .vsync_o(vsync),                // vertical sync
                 .hsync_o(hsync),                // horizontal sync
                 .dv_de_o(dv_de),                // dv display enable

--- a/rtl/upduino/xosera_upd.sv
+++ b/rtl/upduino/xosera_upd.sv
@@ -25,7 +25,7 @@
 //        [BUS_RESET_N]     <RST> |  3           46 | spi_mosi  (17)
 //                         <DONE> |  4           45 | spi_miso  (14)
 //           [BUS_CS_N]   led_red |  5           44 | gpio_20   <N/A w/OSC>
-//         [BUS_RD_NWR] led_green |  6     U     43 | gpio_10   <unused>
+//         [BUS_RD_NWR] led_green |  6     U     43 | gpio_10   <VBLANK>
 //        [BUS_BYTESEL]  led_blue |  7     P     42 | <GND>     <silkscreen errata>
 //                          <+5V> |  8     D     41 | <12 MHz>  <silkscreen errata>
 //                        <+3.3V> |  9     U     40 | gpio_12   [VGA_HS]
@@ -67,7 +67,7 @@ module xosera_upd(
             inout  logic    gpio_38,        // m68k bus data 6
             inout  logic    gpio_28,        // m68k bus data 7
             // right side (USB at top)
-            output logic    gpio_10,        // unused
+            output logic    gpio_10,        // VBLANK (Active high, regardless of resolution)
             output logic    gpio_12,        // video hsync
             output logic    gpio_21,        // video vsync
             output logic    gpio_13,        // video R[3]
@@ -104,6 +104,7 @@ logic [3:0] vga_b;                      // vga blue (4-bits)
 logic       vga_hs;                     // vga hsync
 logic       vga_vs;                     // vga vsync
 logic       dv_de;                      // DV display enable
+logic       in_vblank;                  // In vertical blanking interval
 
 // assign gpio pins to bus signals
 assign bus_cs_n     = led_red;          // RGB red as active low select
@@ -116,7 +117,7 @@ assign bus_data     = { gpio_28, gpio_38, gpio_42, gpio_36, gpio_43, gpio_34, gp
 assign gpio_32      = audio_l;          // left audio channel gpio
 assign gpio_35      = audio_r;          // right audio channel gpio
 
-assign gpio_10      = 1'b0;             // must assign unused output
+assign gpio_10      = in_vblank;        // Vertical blanking indicator
 
 // split tri-state data lines into in/out signals for inside FPGA
 logic bus_out_ena;
@@ -259,6 +260,7 @@ xosera_main xosera_main(
                 .red_o(vga_r),
                 .green_o(vga_g),
                 .blue_o(vga_b),
+                .vblank_o(in_vblank),
                 .vsync_o(vga_vs),
                 .hsync_o(vga_hs),
                 .dv_de_o(dv_de),

--- a/rtl/video_gen.sv
+++ b/rtl/video_gen.sv
@@ -35,6 +35,7 @@ module video_gen(
     input  wire logic [15:0]     vgen_reg_data_i,    // data for internal config register
     // video signal outputs
     output      logic  [3:0]     pal_index_o,        // palette index outputs
+    output      logic            vblank_o,           // Vertical blank indicator (always active high)
     output      logic            vsync_o, hsync_o,   // VGA sync outputs
     output      logic            dv_de_o,            // VGA video active signal (needed for HDMI)
     // standard signals
@@ -275,6 +276,7 @@ always_ff @(posedge clk) begin
         vram_sel_o      <= 1'b0;
         vram_addr_o     <= 16'h0000;
         pal_index_o     <= 4'b0;
+        vblank_o        <= 1'b0;
         hsync_o         <= 1'b0;
         vsync_o         <= 1'b0;
         dv_de_o         <= 1'b0;
@@ -414,9 +416,10 @@ always_ff @(posedge clk) begin
         mem_fetch <= mem_fetch_next;
 
         // set video output signals (color already set)
-        hsync_o <= hsync ? xv::H_SYNC_POLARITY : ~xv::H_SYNC_POLARITY;
-        vsync_o <= vsync ? xv::V_SYNC_POLARITY : ~xv::V_SYNC_POLARITY;
-        dv_de_o <= dv_display_ena;
+        hsync_o  <= hsync ? xv::H_SYNC_POLARITY : ~xv::H_SYNC_POLARITY;
+        vsync_o  <= vsync ? xv::V_SYNC_POLARITY : ~xv::V_SYNC_POLARITY;
+        vblank_o <= vsync;
+        dv_de_o  <= dv_display_ena;
     end
 end
 

--- a/rtl/xosera_iceb_stats.txt
+++ b/rtl/xosera_iceb_stats.txt
@@ -1,9 +1,9 @@
 === iCEBreaker Xosera: PMOD_1B2_DVI12 MODE_848x480
-Package: oss-cad-suite-darwin-x64-20210809
-Yosys 0.9+4249 (git sha1 d8fcf1ab, x86_64-apple-darwin20.2-clang 10.0.0-4ubuntu1 -fPIC -Os)
-nextpnr-ice40 -- Next Generation Place and Route (Version dd637643)
+Package: oss-cad-suite-darwin-x64-20210708
+Yosys 0.9+2406 (git sha1 cf606998, clang 11.0.3 -fPIC -Os)
+nextpnr-ice40 -- Next Generation Place and Route (Version c696e885)
 Info: Device utilisation:
-Info: 	         ICESTORM_LC:  1263/ 5280    23%
+Info: 	         ICESTORM_LC:  1329/ 5280    25%
 Info: 	        ICESTORM_RAM:    17/   30    56%
 Info: 	               SB_IO:    28/   96    29%
 Info: 	               SB_GB:     5/    8    62%
@@ -11,4 +11,4 @@ Info: 	        ICESTORM_PLL:     1/    1   100%
 Info: 	         SB_WARMBOOT:     1/    1   100%
 Info: 	      ICESTORM_SPRAM:     4/    4   100%
 
-Info: Max frequency for clock 'pclk': 41.81 MHz (PASS at 33.77 MHz)
+Info: Max frequency for clock 'pclk': 38.89 MHz (PASS at 33.77 MHz)

--- a/rtl/xosera_main.sv
+++ b/rtl/xosera_main.sv
@@ -45,6 +45,7 @@ module xosera_main(
            input  wire logic [7:0]   bus_data_i,             // 8-bit data bus input
            output logic      [7:0]   bus_data_o,             // 8-bit data bus output
            output logic      [3:0]   red_o, green_o, blue_o, // RGB 4-bit color outputs
+           output logic              vblank_o,               // Vertical blank (active high)
            output logic              hsync_o, vsync_o,       // horizontal and vertical sync
            output logic              dv_de_o,                // pixel visible (aka display enable)
            output logic              audio_l_o, audio_r_o,   // left and right audio PWM output
@@ -110,6 +111,7 @@ logic [15:0]    fontram_data_out    /* verilator public */;
 logic  [3:0]    pal_index       /* verilator public */;
 logic [15:0]    pal_lookup      /* verilator public */;
 
+logic           vblank_1;
 logic           vsync_1;
 logic           hsync_1;
 logic           dv_de_1;
@@ -188,6 +190,7 @@ video_gen video_gen(
     .vgen_reg_data_o(vgen_reg_data_out),
     .vgen_reg_data_i(blit_data_out),
     .pal_index_o(pal_index),
+    .vblank_o(vblank_1),
     .hsync_o(hsync_1),
     .vsync_o(vsync_1),
     .dv_de_o(dv_de_1)
@@ -228,6 +231,7 @@ paletteram paletteram(
 
 // palette RAM lookup (delays video 1 cycle for BRAM)
 always_ff @(posedge clk) begin
+    vblank_o    <= vblank_1;
     vsync_o     <= vsync_1;
     hsync_o     <= hsync_1;
     dv_de_o     <= dv_de_1;

--- a/rtl/xosera_upd_stats.txt
+++ b/rtl/xosera_upd_stats.txt
@@ -1,9 +1,9 @@
-=== UPduino Xosera: PMOD_DIGILENT_VGA MODE_848x480
-Package: oss-cad-suite-darwin-x64-20210809
-Yosys 0.9+4249 (git sha1 d8fcf1ab, x86_64-apple-darwin20.2-clang 10.0.0-4ubuntu1 -fPIC -Os)
-nextpnr-ice40 -- Next Generation Place and Route (Version dd637643)
+=== UPduino Xosera: PMOD_1B2_DVI12 MODE_848x480
+Package: oss-cad-suite-darwin-x64-20210708
+Yosys 0.9+2406 (git sha1 cf606998, clang 11.0.3 -fPIC -Os)
+nextpnr-ice40 -- Next Generation Place and Route (Version c696e885)
 Info: Device utilisation:
-Info: 	         ICESTORM_LC:  1199/ 5280    22%
+Info: 	         ICESTORM_LC:  1254/ 5280    23%
 Info: 	        ICESTORM_RAM:    17/   30    56%
 Info: 	               SB_IO:    36/   96    37%
 Info: 	               SB_GB:     5/    8    62%
@@ -11,4 +11,4 @@ Info: 	        ICESTORM_PLL:     1/    1   100%
 Info: 	         SB_WARMBOOT:     1/    1   100%
 Info: 	      ICESTORM_SPRAM:     4/    4   100%
 
-Info: Max frequency for clock 'pclk': 37.85 MHz (PASS at 33.77 MHz)
+Info: Max frequency for clock 'pclk': 43.62 MHz (PASS at 33.77 MHz)


### PR DESCRIPTION
## TL;DR

As discussed on Discord, this adds an always (i.e. regardless of resolution) active-high VBLANK pin to the video generation, and exposes it on GPIO#10 on the UPduino. I wasn't sure which pin to assign on Icebreaker or what to do with it in the sim, so I've just done the minimum necessary to get it to build (for now).

I've tested this here with both VGA and DVI and it seems to work fine.

## Changes

* Add active_high `vblank_o` port to `video_gen.sv`
* Add logic to make `vblank_o` operate as active-high when in vertical
  blanking interval
* Expose `vblank_o` from `xosera_main.sv`
* Assign `vblank_o` to GPIO#10 on UPduino
* Add minimum necessary to build on other targets

## Still (maybe?) TODO

* Assign `vblank_o` to a pin on Icebreaker (currently left unconnected
  and warning supressed).
* Use/test `vblank_o` in tests/sim ?

## Testing

This change has been tested on UPduino / rosco_m68k using latest IRQ
glue logic and found to work with both VGA and DVI builds.

## Notes

* Feel free to modify, fix or completely ignore this, I'm afraid I'm still quite new to this and am fully aware I may have made a total mess of it 😅 

* I notice this seems to have made a fairly large difference to the utilisation and maximum frequency stats. Totally aware I may have done something dumb, but also wondering if it could just be differences between my machine / tooling?