### PR TITLE
Optimize copper execution

### DIFF
--- a/rtl/xosera_main.sv
+++ b/rtl/xosera_main.sv
@@ -91,13 +91,19 @@ assign  blit_spritemem_wr   = blit_spritemem_sel && blit_wr;
 assign  blit_coppermem_wr   = blit_coppermem_sel && blit_wr;
 
 // Copper
-logic [11:0] copp_wr_addr;
-logic [15:0] copp_data_out;
+logic [15:0] copp_wr_addr       /* verilator public */;
+logic [15:0] copp_data_out      /* verilator public */;
+logic        copp_xr_wr_sel     /* verilator public */;
 
-logic        copp_coppermem_wr;
-logic        copp_colormem_wr;
-logic        copp_tilemem_wr;
-logic        copp_vgen_reg_wr;
+logic        copp_vgen_reg_wr   /* verilator public */;
+logic        copp_colormem_wr   /* verilator public */;
+logic        copp_tilemem_wr    /* verilator public */;
+logic        copp_coppermem_wr  /* verilator public */;
+
+assign  copp_vgen_reg_wr    = copp_xr_wr_sel && !copp_wr_addr[15];
+assign  copp_colormem_wr    = copp_xr_wr_sel && copp_wr_addr[15] && (copp_wr_addr[13:12] == xv::XR_COLOR_MEM[13:12]);
+assign  copp_tilemem_wr     = copp_xr_wr_sel && copp_wr_addr[15] && (copp_wr_addr[13:12] == xv::XR_TILE_MEM[13:12]);
+assign  copp_coppermem_wr   = copp_xr_wr_sel && copp_wr_addr[15] && (copp_wr_addr[13:12] == xv::XR_COPPER_MEM[13:12]);
 
 logic        coppermem_wr_in;
 logic [10:0] coppermem_wr_addr_in;
@@ -318,15 +324,12 @@ copper copper(
     .clk(clk),
     .reset_i(reset_i),
     .vblank_i(vgen_in_vblank),
-    .ram_wr_addr_o(copp_wr_addr),
-    .ram_wr_data_o(copp_data_out),
+    .xr_ram_wr_en_o(copp_xr_wr_sel),
+    .xr_ram_wr_addr_o(copp_wr_addr),
+    .xr_ram_wr_data_o(copp_data_out),
     .coppermem_rd_addr_o(copper_pc),
     .coppermem_rd_en_o(coppermem_rd_en),
     .coppermem_rd_data_i(coppermem_rd_data_out),
-    .coppermem_wr_en_o(copp_coppermem_wr),
-    .colormem_wr_en_o(copp_colormem_wr),
-    .tilemem_wr_en_o(copp_tilemem_wr),
-    .vgen_reg_wr_en_o(copp_vgen_reg_wr),
     .blit_xr_reg_sel_i(blit_vgen_reg_sel),
     .blit_tilemem_sel_i(blit_tilemem_sel),
     .blit_colormem_sel_i(blit_colormem_sel),

--- a/rtl/xosera_upd_stats.txt
+++ b/rtl/xosera_upd_stats.txt
@@ -3,7 +3,7 @@ Package: oss-cad-suite-darwin-x64-20210708
 Yosys 0.9+4292 (open-tool-forge build) (git sha1 50be8fd0, clang 11.0.3 )
 nextpnr-ice40 -- Next Generation Place and Route (Version nightly-20210521)
 Info: Device utilisation:
-Info: 	         ICESTORM_LC:  2432/ 5280    46%
+Info: 	         ICESTORM_LC:  2426/ 5280    45%
 Info: 	        ICESTORM_RAM:    25/   30    83%
 Info: 	               SB_IO:    36/   96    37%
 Info: 	               SB_GB:     8/    8   100%
@@ -11,4 +11,4 @@ Info: 	        ICESTORM_PLL:     1/    1   100%
 Info: 	         SB_WARMBOOT:     1/    1   100%
 Info: 	      ICESTORM_SPRAM:     4/    4   100%
 
-Info: Max frequency for clock 'pclk': 34.89 MHz (PASS at 33.77 MHz)
+Info: Max frequency for clock 'pclk': 36.93 MHz (PASS at 33.77 MHz)

--- a/rtl/xosera_upd_stats.txt
+++ b/rtl/xosera_upd_stats.txt
@@ -1,9 +1,9 @@
 === UPduino Xosera: PMOD_DIGILENT_VGA MODE_848x480
-Package: oss-cad-suite-darwin-x64-20210901
-Yosys 0.9+4290 (git sha1 fe9da25c4, x86_64-apple-darwin20.2-clang 10.0.0-4ubuntu1 -fPIC -Os)
-nextpnr-ice40 -- Next Generation Place and Route (Version 0c40bed4)
+Package: oss-cad-suite-darwin-x64-20210708
+Yosys 0.9+4292 (open-tool-forge build) (git sha1 50be8fd0, clang 11.0.3 )
+nextpnr-ice40 -- Next Generation Place and Route (Version nightly-20210521)
 Info: Device utilisation:
-Info: 	         ICESTORM_LC:  2417/ 5280    45%
+Info: 	         ICESTORM_LC:  2432/ 5280    46%
 Info: 	        ICESTORM_RAM:    25/   30    83%
 Info: 	               SB_IO:    36/   96    37%
 Info: 	               SB_GB:     8/    8   100%
@@ -11,4 +11,4 @@ Info: 	        ICESTORM_PLL:     1/    1   100%
 Info: 	         SB_WARMBOOT:     1/    1   100%
 Info: 	      ICESTORM_SPRAM:     4/    4   100%
 
-Info: Max frequency for clock 'pclk': 35.91 MHz (PASS at 33.77 MHz)
+Info: Max frequency for clock 'pclk': 34.89 MHz (PASS at 33.77 MHz)


### PR DESCRIPTION
This optimises the copper execution pipeline, such that all instructions now execute in four pixels (in the general case - there's an exception for the first instruction in a frame which needs five).