### PR TITLE
Tighten up copper reset and fix a bug

### DIFF
--- a/rtl/video_gen.sv
+++ b/rtl/video_gen.sv
@@ -31,7 +31,6 @@ module video_gen(
     // outputs for copper
     output      logic [10:0]     h_count_o,          // Horizontal video counter
     output      logic [10:0]     v_count_o,          // Vertical video counter
-    output      logic            in_vblank_o,
     // video memories
     output      logic            vram_sel_o,         // vram read select
     output      logic [15:0]     vram_addr_o,        // vram word address out (16x64K)
@@ -157,7 +156,6 @@ logic           h_start_line_fetch;
 assign h_count_o    = h_count;
 assign v_count_o    = v_count;
 
-always_comb in_vblank_o = v_state != STATE_VISIBLE;
 
 // video config registers read/write
 always_ff @(posedge clk) begin

--- a/rtl/xosera_main.sv
+++ b/rtl/xosera_main.sv
@@ -179,7 +179,6 @@ logic [15:0]    spritemem_data_out  /* verilator public */;
 logic  [7:0]    color_index         /* verilator public */;
 logic [15:0]    pal_lookup          /* verilator public */;
 
-logic           vgen_in_vblank;
 logic           vsync_1;
 logic           hsync_1;
 logic           dv_de_1;
@@ -268,7 +267,6 @@ video_gen video_gen(
     .dv_de_o(dv_de_1),
     .h_count_o(video_h_count),
     .v_count_o(video_v_count),
-    .in_vblank_o(vgen_in_vblank),
     .reset_i(reset_i),
     .clk(clk)
 );
@@ -323,7 +321,6 @@ spritemem spritemem(
 copper copper(
     .clk(clk),
     .reset_i(reset_i),
-    .vblank_i(vgen_in_vblank),
     .xr_ram_wr_en_o(copp_xr_wr_sel),
     .xr_ram_wr_addr_o(copp_wr_addr),
     .xr_ram_wr_data_o(copp_data_out),


### PR DESCRIPTION
* Copper was off-by-one bit in decoding of horizontal position
* Copper now handles reset internally, and execution begins exactly on pixel zero of new frame

This doesn't fix the reported line issue, but I found these while investigating that and thought they should be fixed...