### PR TITLE
Streamline

### DIFF
--- a/rtl/blitter.sv
+++ b/rtl/blitter.sv
@@ -36,24 +36,6 @@ module blitter(
     input  wire logic            clk
     );
 
-localparam [31:0] githash = 32'H`GITHASH;
-localparam [11:0] version = 12'H`VERSION;
-
-logic [8*8:1]  logostring = "Xosera v";    // boot msg
-
-`ifndef TESTPATTERN
-localparam CLEARDATA = 16'h0220;    // value VRAM cleared to on init (blue+white space) TODO: zero for final?
-`endif
-
-typedef enum logic [4:0] {
-    INIT, CLEAR, LOGO_1, LOGO_2, LOGO_3, LOGO_4, LOGO_5, LOGO_6, LOGO_7, LOGO_8,
-    LOGO_V0, LOGO_V1, LOGO_V2, LOGO_V3, LOGO_V4, LOGO_V5,
-    LOGO_H0, LOGO_H1, LOGO_H2, LOGO_H3, LOGO_H4, LOGO_H5, LOGO_H6, LOGO_H7, LOGO_END,
-    IDLE
-} blit_state_t;
-
-blit_state_t    blit_state;
-
 // read/write storage for first 4 blitter registers
 logic [15:0]    reg_xr_addr;           // XR read/write address (XR_ADDR)
 logic [15:0]    xr_rd_data;             // word read from XR
@@ -72,6 +54,7 @@ logic [15:0]    vram_rw_data;           // word read from VRAM (for RW_ADDR)
 logic           vram_rw_rd;             // flag for VRAM RW read outstanding
 logic           vram_rw_wr;             // flag for VRAM RW write outstanding
 logic           vram_rw_ack;            // flag for VRAM RW read acknowledged 
+logic [3:0]     wr_nibmask;             // flag to mask nibbles when writing 16-bit word
 
 // internal storage
 logic  [3:0]    intr_mask;              // interrupt mask
@@ -83,35 +66,22 @@ logic  [7:0]    reg_data_even;          // byte written to even byte of XM_DATA/
 logic  [3:0]    reg_other_reg;          // register associated with reg_other_even
 logic  [7:0]    reg_other_even;         // even byte storage (until odd byte)
 logic  [7:0]    reg_even_byte;          // either reg_other_even or zero if different register
-assign          reg_even_byte = (reg_other_reg == bus_reg_num) ? reg_other_even : 8'h00;
 
 logic           bus_write_strobe;       // strobe when a word of data written
 logic           bus_read_strobe;        // strobe when a word of data read
 logic           bus_bytesel;            // msb/lsb on bus
 logic  [7:0]    bus_data_byte;          // data byte from bus
 
-// write only storage for the rest
-logic [16:0]    blit_count;             // (extra bit for underflow/flag)
-// TODO logic [15:0]    reg_rd_mod;
-// TODO logic [15:0]    reg_wr_mod;
-// TODO logic [15:0]    reg_width;
-// TODO logic           blit_2d;
-// TODO logic           blit_const;
+logic [15:0]    ms_timer;               // 1/10 ms timer (visible 16 bits)
+logic [11:0]    ms_timer_frac;          // internal clock counter for 1/10 ms
 
-// TODO logic [16:0]    width_counter;          // blit count (extra bit for underflow/done)
-// TODO logic [15:0]    blit_rd_addr;           // TODO VRAM read address
-// TODO logic [15:0]    blit_wr_addr;           // TODO VRAM write address
-logic           blit_busy;
-assign          blit_busy = ~blit_count[16]; // when blit_count underflows, high bit will be set
-// TODO logic           blit_line_end;
-// TODO assign          blit_line_end = width_counter[16];  // when width_counter underflows, high bit will be set
-
-logic [15:0] ms_timer;      // TODO
-logic [11:0] ms_timer_frac;  // TODO
-logic [3:0] wr_nibmask;      // TODO
-
+// output interrupt mask
 assign intr_mask_o = intr_mask;
 
+// output nibble mask
+assign blit_mask_o = wr_nibmask;   // TODO replace blit_wr with just mask (non-zero for write)?
+
+// debug "ack" bus strobe
 assign bus_ack_o = (bus_write_strobe | bus_read_strobe);    // TODO: debug
 
 // bus_interface handles signal synchronization, CS and register writes to Xosera
@@ -151,11 +121,11 @@ function [7:0] reg_read(
         xv::XM_DATA[3:0],
         xv::XM_DATA_2[3:0]:     reg_read = !b_sel ? vram_rd_data[15:8]  : vram_rd_data[7:0];
 
-        xv::XM_SYS_CTRL[3:0]:   reg_read = !b_sel ? { 4'bx, wr_nibmask }: { blit_busy, 3'bx, intr_mask };
+        xv::XM_SYS_CTRL[3:0]:   reg_read = !b_sel ? { 4'b0, wr_nibmask }: { 4'b0, intr_mask };
         xv::XM_TIMER[3:0]:      reg_read = !b_sel ? ms_timer[15:8]      : ms_timer[7:0];
 
-        xv::XM_UNUSED_A[3:0]:   reg_read = 8'bx;
-        xv::XM_UNUSED_B[3:0]:   reg_read = 8'bx;
+        xv::XM_UNUSED_A[3:0]:   reg_read = 8'b0;
+        xv::XM_UNUSED_B[3:0]:   reg_read = 8'b0;
 
         xv::XM_RW_INCR[3:0]:    reg_read = !b_sel ? reg_rw_incr[15:8]   : reg_rw_incr[7:0];
         xv::XM_RW_ADDR[3:0]:    reg_read = !b_sel ? reg_rw_addr[15:8]   : reg_rw_addr[7:0];
@@ -165,17 +135,7 @@ function [7:0] reg_read(
     endcase
 endfunction
 
-function [7:0] hex_digit(
-    input logic[3:0]    nib
-    );
-    if (nib > 9) begin
-        hex_digit = 8'h57 + { 4'h0, nib };
-    end
-    else begin
-        hex_digit = 8'h30 + { 4'h0, nib };
-    end
-endfunction
-
+// 1/10th ms timer counter
 always_ff @(posedge clk) begin
     if (reset_i) begin
         ms_timer <= 16'h0000;
@@ -189,7 +149,8 @@ always_ff @(posedge clk) begin
     end
 end
 
-assign blit_mask_o = { blit_wr_o, blit_wr_o,  blit_wr_o, blit_wr_o };   // TODO replace blit_wr with just mask (non-zero for write)
+// even byte to write (since write happens on odd byte)
+assign reg_even_byte = (reg_other_reg == bus_reg_num) ? reg_other_even : 8'h00;
 
 always_ff @(posedge clk) begin
     if (reset_i) begin
@@ -197,6 +158,7 @@ always_ff @(posedge clk) begin
         reconfig_o      <= 1'b0;
         boot_select_o   <= 2'b00;
         intr_clear_o    <= 4'b0;
+        wr_nibmask      <= 4'b1111;
         intr_mask       <= 4'b1000;
         vram_rd         <= 1'b0;
         vram_rd_ack     <= 1'b0;
@@ -209,17 +171,6 @@ always_ff @(posedge clk) begin
         blit_addr_o     <= 16'h0000;
         blit_data_o     <= 16'h0000;
 
-        // internal blitter state
-        blit_state      <= INIT;
-// TODO         blit_2d             <= 1'b0;
-// TODO         blit_const          <= 1'b0;
-// TODO         width_counter       <= 17'h00000;   // 16th bit is set on underflow
-// TODO         blit_rd_addr        <= 16'h0000;
-// TODO         blit_wr_addr        <= 16'h0000;
-// TODO         reg_rd_mod          <= 16'h0000;
-// TODO         reg_wr_mod          <= 16'h0000;
-// TODO         reg_width           <= 16'h0000;
-
         // xosera registers
         reg_xr_addr     <= 16'h0000;
         reg_rd_addr     <= 16'h0000;
@@ -228,7 +179,6 @@ always_ff @(posedge clk) begin
         reg_wr_incr     <= 16'h0000;
         reg_rw_addr     <= 16'h0000;
         reg_rw_incr     <= 16'h0000;
-        blit_count      <= 17'h10000;   // 16th bit is set on underfow
         reg_data_even   <= 8'h00;
         reg_other_even  <= 8'h00;
         reg_other_reg   <= 4'h0;
@@ -272,11 +222,6 @@ always_ff @(posedge clk) begin
             // if we did a wr write, increment wr addr
             if (blit_vram_sel_o && blit_wr_o && !vram_rw_wr) begin
                 reg_wr_addr  <= reg_wr_addr + reg_wr_incr;
-
-                // decrement count register if blitter busy
-                if (blit_busy) begin
-                    blit_count    <= blit_count - 1'b1;
-                end
             end
 
             // if we did a rw write, increment rw addr
@@ -399,205 +344,15 @@ always_ff @(posedge clk) begin
             if (bus_reg_num == xv::XM_DATA || bus_reg_num == xv::XM_DATA_2) begin
                 blit_addr_o         <= reg_rd_addr;      // output read address
                 blit_vram_sel_o     <= 1'b1;            // select VRAM
-                vram_rd             <= 1'b1;            // remember pending vramread request
+                vram_rd             <= 1'b1;            // remember pending vram read request
             end
             // if read from rw_data then pre-read next vram rw address
             if (bus_reg_num == xv::XM_RW_DATA || bus_reg_num == xv::XM_RW_DATA_2) begin
                 blit_addr_o         <= reg_rw_addr;      // output read address
                 blit_vram_sel_o     <= 1'b1;            // select VRAM
-                vram_rw_rd          <= 1'b1;            // remember pending vramread request
+                vram_rw_rd          <= 1'b1;            // remember pending vram read request
             end
         end
-
-        case (vgen_sel_i ? IDLE : blit_state)
-            IDLE: begin
-            end
-            INIT: begin
-                // NOTE: relies on initial state set by reset
-                blit_vram_sel_o <= 1'b1;
-                blit_wr_o       <= 1'b1;
-`ifdef TESTPATTERN
-                blit_data_o     <= 16'h0000;
-`else
-                blit_data_o     <= CLEARDATA;
-`endif
-                blit_addr_o     <= 16'h0000;
-`ifdef SYNTHESIS
-                blit_count       <= 17'h0FFFF;
-`else
-                blit_count       <= 17'h00FFF;        // smaller clear for simulation
-`endif
-                reg_wr_incr      <= 16'h0001;
-                blit_state      <= CLEAR;
-            end
-            CLEAR: begin
-                if (blit_busy) begin
-                    blit_vram_sel_o <= 1'b1;
-                    blit_wr_o       <= 1'b1;
-`ifdef TESTPATTERN
-                    if (reg_wr_addr[3:0] == 4'h1) begin
-                        blit_data_o     <= { 8'h02, reg_wr_addr[15:8] };
-                    end
-                    else if (reg_wr_addr[3:0] == 4'h2) begin
-                        blit_data_o     <= { 8'h02, reg_wr_addr[7:4], 4'h0 };
-                    end
-                    else begin
-                        blit_data_o     <= {(reg_wr_addr[7:4] ^ 4'b1111), reg_wr_addr[7:4], reg_wr_addr[7:0] };
-                    end
-
-`endif
-                    blit_state      <= CLEAR;
-                end
-                else begin
-`ifdef TESTPATTERN
-                    blit_state      <= LOGO_END;
-`else
-                    blit_state      <= LOGO_1;
-`endif
-                end
-            end
-            LOGO_1: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_addr_o         <= (1 * xv::TILES_WIDE + 1);
-                reg_wr_addr         <= (1 * xv::TILES_WIDE + 2);
-                blit_data_o         <= { 8'h0F, logostring[8*8-:8] };
-                blit_state          <= LOGO_2;
-            end
-            LOGO_2: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h0e, logostring[7*8-:8] };
-                blit_state          <= LOGO_3;
-            end
-            LOGO_3: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h0c, logostring[6*8-:8] };
-                blit_state          <= LOGO_4;
-            end
-            LOGO_4: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h0b, logostring[5*8-:8] };
-                blit_state          <= LOGO_5;
-            end
-            LOGO_5: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, logostring[4*8-:8] };
-                blit_state          <= LOGO_6;
-            end
-            LOGO_6: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h05, logostring[3*8-:8] };
-                blit_state          <= LOGO_7;
-            end
-            LOGO_7: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h07, logostring[2*8-:8] };
-                blit_state          <= LOGO_8;
-            end
-            LOGO_8: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, logostring[1*8-:8] };
-                blit_state          <= LOGO_V0;
-            end
-            LOGO_V0: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, hex_digit(version[3*4-1-:4]) };
-                blit_state          <= LOGO_V1;
-            end
-            LOGO_V1: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, 8'h2e };    // '.'
-                blit_state          <= LOGO_V2;
-            end
-            LOGO_V2: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, hex_digit(version[2*4-1-:4]) };
-                blit_state          <= LOGO_V3;
-            end
-            LOGO_V3: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, hex_digit(version[1*4-1-:4]) };
-                blit_state          <= LOGO_V4;
-            end
-            LOGO_V4: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, 8'h20 };    // ' '
-                blit_state          <= LOGO_V5;
-            end
-            LOGO_V5: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, 8'h23 };    // '#'
-                blit_state          <= LOGO_H0;
-            end
-            LOGO_H0: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, hex_digit(githash[8*4-1-:4]) };
-                blit_state          <= LOGO_H1;
-            end
-            LOGO_H1: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, hex_digit(githash[7*4-1-:4]) };
-                blit_state          <= LOGO_H2;
-            end
-            LOGO_H2: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, hex_digit(githash[6*4-1-:4]) };
-                blit_state          <= LOGO_H3;
-            end
-            LOGO_H3: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, hex_digit(githash[5*4-1-:4]) };
-                blit_state          <= LOGO_H4;
-            end
-            LOGO_H4: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, hex_digit(githash[4*4-1-:4]) };
-                blit_state          <= LOGO_H5;
-            end
-            LOGO_H5: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, hex_digit(githash[3*4-1-:4]) };
-                blit_state          <= LOGO_H6;
-            end
-            LOGO_H6: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, hex_digit(githash[2*4-1-:4]) };
-                blit_state          <= LOGO_H7;
-            end
-            LOGO_H7: begin
-                blit_vram_sel_o     <= 1'b1;
-                blit_wr_o           <= 1'b1;
-                blit_data_o         <= { 8'h02, hex_digit(githash[1*4-1-:4]) };
-                blit_state          <= LOGO_END;
-            end
-            LOGO_END: begin
-                reg_wr_addr        <= 16'h0000;
-                blit_state          <= IDLE;
-            end
-            default: begin
-                blit_state <= IDLE;
-            end
-        endcase
     end
 end
 endmodule

--- a/rtl/bus_interface.sv
+++ b/rtl/bus_interface.sv
@@ -18,7 +18,7 @@ module bus_interface(
            input  wire logic  [3:0]  bus_reg_num_i,          // register number
            input  wire logic         bus_bytesel_i,          // 0=even byte, 1=odd byte
            input  wire logic  [7:0]  bus_data_i,             // 8-bit data bus input (broken out from bi-dir data bus)
-           // blitter interface signals
+           // register interface signals
            output      logic         write_strobe_o,         // strobe for register write
            output      logic         read_strobe_o,          // strobe for register read
            output      logic  [3:0]  reg_num_o,              // register number read/written

--- a/rtl/copper.sv
+++ b/rtl/copper.sv
@@ -147,10 +147,10 @@ module copper(
     output       logic [10:0]   coppermem_rd_addr_o,
     output       logic          coppermem_rd_en_o,
     input   wire logic [15:0]   coppermem_rd_data_i,
-    input   wire logic          blit_xr_reg_sel_i,
-    input   wire logic          blit_tilemem_sel_i,
-    input   wire logic          blit_colormem_sel_i,
-    input   wire logic          blit_coppermem_sel_i,
+    input   wire logic          regs_xr_reg_sel_i,
+    input   wire logic          regs_tilemem_sel_i,
+    input   wire logic          regs_colormem_sel_i,
+    input   wire logic          regs_coppermem_sel_i,
     input   wire logic          copp_reg_wr_i,          // strobe to write internal config register number
     input   wire logic  [3:0]   copp_reg_num_i,         // internal config register number
     input   wire logic [15:0]   copp_reg_data_i,        // data for internal config register
@@ -378,7 +378,7 @@ always_ff @(posedge clk) begin
                             // up...
                             INSN_MOVER: begin
                                 // mover
-                                if (!blit_xr_reg_sel_i) begin
+                                if (!regs_xr_reg_sel_i) begin
                                     xr_wr_strobe            <= 1'b1;
                                     ram_wr_addr_out[15:8]   <= 8'h0;
                                     ram_wr_addr_out[7:0]    <= r_insn[23:16];
@@ -392,7 +392,7 @@ always_ff @(posedge clk) begin
                             end
                             INSN_MOVEF: begin
                                 // movef
-                                if (!blit_tilemem_sel_i) begin
+                                if (!regs_tilemem_sel_i) begin
                                     xr_wr_strobe            <= 1'b1;
                                     ram_wr_addr_out[15:12]  <= xv::XR_TILE_MEM[15:12];
                                     ram_wr_addr_out[11:0]   <= r_insn[27:16];
@@ -406,7 +406,7 @@ always_ff @(posedge clk) begin
                             end
                             INSN_MOVEP: begin
                                 // movep
-                                if (!blit_colormem_sel_i) begin
+                                if (!regs_colormem_sel_i) begin
                                     xr_wr_strobe            <= 1'b1;
                                     ram_wr_addr_out[15:8]   <= xv::XR_COLOR_MEM[15:8];
                                     ram_wr_addr_out[7:0]    <= r_insn[23:16];
@@ -420,7 +420,7 @@ always_ff @(posedge clk) begin
                             end
                             INSN_MOVEC: begin
                                 // movec
-                                if (!blit_coppermem_sel_i) begin
+                                if (!regs_coppermem_sel_i) begin
                                     xr_wr_strobe            <= 1'b1;
                                     ram_wr_addr_out[15:11]  <= xv::XR_COPPER_MEM[15:11];
                                     ram_wr_addr_out[10:0]   <= r_insn[26:16];

--- a/rtl/sim/xosera_sim.cpp
+++ b/rtl/sim/xosera_sim.cpp
@@ -366,12 +366,12 @@ BusInterface bus;
 int          BusInterface::test_data_len   = 999;
 uint16_t     BusInterface::test_data[1024] = {
     // test data
-    REG_WAITVSYNC(),                       // show boot screen
-    REG_W(XR_ADDR, XR_COPP_CTRL),          // do copper test on bootscreen...
+    REG_WAITVSYNC(),                     // show boot screen
+    REG_W(XR_ADDR, XR_COPP_CTRL),        // do copper test on bootscreen...
     REG_W(XR_DATA, 0x8000),
-    REG_WAITVSYNC(),                       // show boot screen
-    REG_WAITVSYNC(),                       // show boot screen
-    REG_W(XR_ADDR, XR_COPP_CTRL),          // disable copper so as not to ruin image tests.
+    REG_WAITVSYNC(),                     // show boot screen
+    REG_WAITVSYNC(),                     // show boot screen
+    REG_W(XR_ADDR, XR_COPP_CTRL),        // disable copper so as not to ruin image tests.
     REG_W(XR_DATA, 0x0000),
     REG_W(XR_ADDR, XR_PA_GFX_CTRL),        // set 1-BPP BMAP
     REG_W(XR_DATA, 0x0040),
@@ -666,14 +666,14 @@ int main(int argc, char ** argv)
 
         if (frame_num > 1)
         {
-            if (top->xosera_main->blit_vram_sel && top->xosera_main->blit_wr)
+            if (top->xosera_main->regs_vram_sel && top->xosera_main->regs_wr)
             {
-                printf(" => write VRAM[0x%04x]=0x%04x\n", top->xosera_main->blit_addr, top->xosera_main->blit_data_out);
+                printf(" => write VRAM[0x%04x]=0x%04x\n", top->xosera_main->regs_addr, top->xosera_main->regs_data_out);
             }
 
-            if (top->xosera_main->blit_xr_sel && top->xosera_main->blit_wr)
+            if (top->xosera_main->regs_xr_sel && top->xosera_main->regs_wr)
             {
-                printf(" => write AUX[0x%04x]=0x%04x\n", top->xosera_main->blit_addr, top->xosera_main->blit_data_out);
+                printf(" => write AUX[0x%04x]=0x%04x\n", top->xosera_main->regs_addr, top->xosera_main->regs_data_out);
             }
         }
 

--- a/rtl/sim/xosera_tb.sv
+++ b/rtl/sim/xosera_tb.sv
@@ -235,78 +235,78 @@ always begin
     bus_reg_num = 4'b0;
     bus_data_in = 8'b0;
 
-    if (xosera.blitter.blit_state == xosera.blitter.IDLE) begin
+    # 8ms;
 
-        // TODO hacked in copper enable
-        #(M68K_PERIOD * 2)  xvid_setw(XM_XR_ADDR, XR_COPP_CTRL);
-        #(M68K_PERIOD * 2)  xvid_setw(XM_XR_DATA, 16'h8000);
-        // TODO end
+    // TODO hacked in copper enable
+    #(M68K_PERIOD * 2)  xvid_setw(XM_XR_ADDR, XR_COPP_CTRL);
+    #(M68K_PERIOD * 2)  xvid_setw(XM_XR_DATA, 16'h8000);
+    // TODO end
         
         
 `ifdef LOAD_MONOBM
-        while (xosera.video_gen.last_frame_pixel != 1'b1) begin
-            # 1ns;
-        end
+    while (xosera.video_gen.last_frame_pixel != 1'b1) begin
+        # 1ns;
+    end
 
-        #(M68K_PERIOD * 2)  xvid_setw(XM_WR_INCR, test_inc);
-        #(M68K_PERIOD * 2)  xvid_setw(XM_WR_ADDR, 16'h0000);
-        #(M68K_PERIOD * 2)  xvid_setw(XM_XR_ADDR, XR_PA_GFX_CTRL);
-        #(M68K_PERIOD * 2)  xvid_setw(XM_XR_DATA, 16'h0040);
+    #(M68K_PERIOD * 2)  xvid_setw(XM_WR_INCR, test_inc);
+    #(M68K_PERIOD * 2)  xvid_setw(XM_WR_ADDR, 16'h0000);
+    #(M68K_PERIOD * 2)  xvid_setw(XM_XR_ADDR, XR_PA_GFX_CTRL);
+    #(M68K_PERIOD * 2)  xvid_setw(XM_XR_DATA, 16'h0040);
 
-        inject_file("sim/mountains_mono_640x480w.raw", XM_DATA);  // pump binary file into DATA
+    inject_file("sim/mountains_mono_640x480w.raw", XM_DATA);  // pump binary file into DATA
 
-        # 1000ms;
+    # 1000ms;
 
 `endif
 `ifdef ZZZUNDEF // read test
-        # 10ms;
-        #(M68K_PERIOD * 4)  write_reg(1'b0, XM_WR_ADDR, test_addr[15:8]);
-        #(M68K_PERIOD * 4)  write_reg(1'b1, XM_WR_ADDR, test_addr[7:0]);
+    # 10ms;
+    #(M68K_PERIOD * 4)  write_reg(1'b0, XM_WR_ADDR, test_addr[15:8]);
+    #(M68K_PERIOD * 4)  write_reg(1'b1, XM_WR_ADDR, test_addr[7:0]);
 
-        #(M68K_PERIOD * 4)  write_reg(1'b0, XM_WR_INCR, test_inc[15:8]);
-        #(M68K_PERIOD * 4)  write_reg(1'b1, XM_WR_INCR, test_inc[7:0]);
+    #(M68K_PERIOD * 4)  write_reg(1'b0, XM_WR_INCR, test_inc[15:8]);
+    #(M68K_PERIOD * 4)  write_reg(1'b1, XM_WR_INCR, test_inc[7:0]);
 
-        #(M68K_PERIOD * 4)  write_reg(1'b0, XM_DATA, test_data0[15:8]);
-        #(M68K_PERIOD * 4)  write_reg(1'b1, XM_DATA, test_data0[7:0]);
+    #(M68K_PERIOD * 4)  write_reg(1'b0, XM_DATA, test_data0[15:8]);
+    #(M68K_PERIOD * 4)  write_reg(1'b1, XM_DATA, test_data0[7:0]);
 
-        #(M68K_PERIOD * 4)  write_reg(1'b0, XM_DATA, test_data1[15:8]);
-        #(M68K_PERIOD * 4)  write_reg(1'b1, XM_DATA, test_data1[7:0]);
+    #(M68K_PERIOD * 4)  write_reg(1'b0, XM_DATA, test_data1[15:8]);
+    #(M68K_PERIOD * 4)  write_reg(1'b1, XM_DATA, test_data1[7:0]);
 
-        #(M68K_PERIOD * 4)  write_reg(1'b0, XM_DATA, test_data2[15:8]);
-        #(M68K_PERIOD * 4)  write_reg(1'b1, XM_DATA, test_data2[7:0]);
+    #(M68K_PERIOD * 4)  write_reg(1'b0, XM_DATA, test_data2[15:8]);
+    #(M68K_PERIOD * 4)  write_reg(1'b1, XM_DATA, test_data2[7:0]);
 
-        #(M68K_PERIOD * 4)  write_reg(1'b0, XVID_RD_INC, test_inc[15:8]);
-        #(M68K_PERIOD * 4)  write_reg(1'b1, XVID_RD_INC, test_inc[7:0]);
+    #(M68K_PERIOD * 4)  write_reg(1'b0, XVID_RD_INC, test_inc[15:8]);
+    #(M68K_PERIOD * 4)  write_reg(1'b1, XVID_RD_INC, test_inc[7:0]);
 
-        #(M68K_PERIOD * 4)  write_reg(1'b0, XM_RD_ADDR, test_addr[15:8]);
-        #(M68K_PERIOD * 4)  write_reg(1'b1, XM_RD_ADDR, test_addr[7:0]);
+    #(M68K_PERIOD * 4)  write_reg(1'b0, XM_RD_ADDR, test_addr[15:8]);
+    #(M68K_PERIOD * 4)  write_reg(1'b1, XM_RD_ADDR, test_addr[7:0]);
 
-        #(M68K_PERIOD * 4)  read_reg(1'b0, XM_DATA, readword[15:8]);
-        #(M68K_PERIOD * 4)  read_reg(1'b1, XM_DATA, readword[7:0]);
-        $display("%0t REG READ R[%x] => %04x", $realtime, xosera.blitter.bus_reg_num, readword);
+    #(M68K_PERIOD * 4)  read_reg(1'b0, XM_DATA, readword[15:8]);
+    #(M68K_PERIOD * 4)  read_reg(1'b1, XM_DATA, readword[7:0]);
+    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.reg_interface.bus_reg_num, readword);
 
-        #(M68K_PERIOD * 4)  read_reg(1'b0, XM_DATA, readword[15:8]);
-        #(M68K_PERIOD * 4)  read_reg(1'b1, XM_DATA, readword[7:0]);
-        $display("%0t REG READ R[%x] => %04x", $realtime, xosera.blitter.bus_reg_num, readword);
+    #(M68K_PERIOD * 4)  read_reg(1'b0, XM_DATA, readword[15:8]);
+    #(M68K_PERIOD * 4)  read_reg(1'b1, XM_DATA, readword[7:0]);
+    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.reg_interface.bus_reg_num, readword);
 
-        #(M68K_PERIOD * 4)  read_reg(1'b0, XM_DATA, readword[15:8]);
-        #(M68K_PERIOD * 4)  read_reg(1'b1, XM_DATA, readword[7:0]);
-        $display("%0t REG READ R[%x] => %04x", $realtime, xosera.blitter.bus_reg_num, readword);
+    #(M68K_PERIOD * 4)  read_reg(1'b0, XM_DATA, readword[15:8]);
+    #(M68K_PERIOD * 4)  read_reg(1'b1, XM_DATA, readword[7:0]);
+    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.reg_interface.bus_reg_num, readword);
 
-        #(M68K_PERIOD * 4)  write_reg(1'b0, XM_WR_ADDR, test_addr2[15:8]);
-        #(M68K_PERIOD * 4)  write_reg(1'b1, XM_WR_ADDR, test_addr2[7:0]);
+    #(M68K_PERIOD * 4)  write_reg(1'b0, XM_WR_ADDR, test_addr2[15:8]);
+    #(M68K_PERIOD * 4)  write_reg(1'b1, XM_WR_ADDR, test_addr2[7:0]);
 
-        #(M68K_PERIOD * 4)  write_reg(1'b0, XM_DATA, test_data2[15:8]);
-        #(M68K_PERIOD * 4)  write_reg(1'b1, XM_DATA, test_data2[7:0]);
+    #(M68K_PERIOD * 4)  write_reg(1'b0, XM_DATA, test_data2[15:8]);
+    #(M68K_PERIOD * 4)  write_reg(1'b1, XM_DATA, test_data2[7:0]);
 
-        #(M68K_PERIOD * 4)  write_reg(1'b0, XM_RD_ADDR, test_addr2[15:8]);
-        #(M68K_PERIOD * 4)  write_reg(1'b1, XM_RD_ADDR, test_addr2[7:0]);
+    #(M68K_PERIOD * 4)  write_reg(1'b0, XM_RD_ADDR, test_addr2[15:8]);
+    #(M68K_PERIOD * 4)  write_reg(1'b1, XM_RD_ADDR, test_addr2[7:0]);
 
-        #(M68K_PERIOD * 4);
+    #(M68K_PERIOD * 4);
 
-        #(M68K_PERIOD * 4)  read_reg(1'b0, XM_DATA, readword[15:8]);
-        #(M68K_PERIOD * 4)  read_reg(1'b1, XM_DATA, readword[7:0]);
-        $display("%0t REG READ R[%x] => %04x", $realtime, xosera.blitter.bus_reg_num, readword);
+    #(M68K_PERIOD * 4)  read_reg(1'b0, XM_DATA, readword[15:8]);
+    #(M68K_PERIOD * 4)  read_reg(1'b1, XM_DATA, readword[7:0]);
+    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.reg_interface.bus_reg_num, readword);
 
 `endif
 
@@ -317,21 +317,21 @@ always begin
 
     #(M68K_PERIOD * 4)  read_reg(1'b0, XM_XR_DATA, readword[15:8]);
     #(M68K_PERIOD * 4)  read_reg(1'b1, XM_XR_DATA, readword[7:0]);
-    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.blitter.bus_reg_num, readword);
+    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.reg_interface.bus_reg_num, readword);
 
     #(M68K_PERIOD * 4)  write_reg(1'b0, XM_XR_ADDR, 8'h00);
     #(M68K_PERIOD * 4)  write_reg(1'b1, XM_XR_ADDR, 8'h01);
 
     #(M68K_PERIOD * 4)  read_reg(1'b0, XM_XR_DATA, readword[15:8]);
     #(M68K_PERIOD * 4)  read_reg(1'b1, XM_XR_DATA, readword[7:0]);
-    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.blitter.bus_reg_num, readword);
+    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.reg_interface.bus_reg_num, readword);
 
     #(M68K_PERIOD * 4)  write_reg(1'b0, XM_XR_ADDR, 8'h00);
     #(M68K_PERIOD * 4)  write_reg(1'b1, XM_XR_ADDR, 8'h02);
 
     #(M68K_PERIOD * 4)  read_reg(1'b0, XM_XR_DATA, readword[15:8]);
     #(M68K_PERIOD * 4)  read_reg(1'b1, XM_XR_DATA, readword[7:0]);
-    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.blitter.bus_reg_num, readword);
+    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.reg_interface.bus_reg_num, readword);
 
     #(1ms) ;
     #(M68K_PERIOD * 4)  write_reg(1'b0, XM_XR_ADDR, 8'h00);
@@ -339,14 +339,14 @@ always begin
 
     #(M68K_PERIOD * 4)  read_reg(1'b0, XM_XR_DATA, readword[15:8]);
     #(M68K_PERIOD * 4)  read_reg(1'b1, XM_XR_DATA, readword[7:0]);
-    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.blitter.bus_reg_num, readword);
+    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.reg_interface.bus_reg_num, readword);
 
     #(M68K_PERIOD * 4)  write_reg(1'b0, XM_XR_ADDR, 8'h00);
     #(M68K_PERIOD * 4)  write_reg(1'b1, XM_XR_ADDR, 8'h03);
 
     #(M68K_PERIOD * 4)  read_reg(1'b0, XM_XR_DATA, readword[15:8]);
     #(M68K_PERIOD * 4)  read_reg(1'b1, XM_XR_DATA, readword[7:0]);
-    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.blitter.bus_reg_num, readword);
+    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.reg_interface.bus_reg_num, readword);
 
     #(1500us) ;
     #(M68K_PERIOD * 4)  write_reg(1'b0, XM_XR_ADDR, 8'h00);
@@ -354,14 +354,9 @@ always begin
 
     #(M68K_PERIOD * 4)  read_reg(1'b0, XM_XR_DATA, readword[15:8]);
     #(M68K_PERIOD * 4)  read_reg(1'b1, XM_XR_DATA, readword[7:0]);
-    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.blitter.bus_reg_num, readword);
+    $display("%0t REG READ R[%x] => %04x", $realtime, xosera.reg_interface.bus_reg_num, readword);
 
 `endif
-
-    end
-    else begin
-        #(M68K_PERIOD * 4);
-    end
 end
 /* verilator lint_on LATCH */
 `endif
@@ -369,20 +364,18 @@ end
 integer flag = 0;
 logic [15:0] last_rd_addr = 0;
 always @(negedge clk) begin
-    if (xosera.blitter.blit_state == xosera.blitter.IDLE) begin
-        if (xosera.blitter.blit_vram_sel_o) begin
-            if (xosera.blitter.blit_wr_o) begin
-                $display("%0t Write VRAM[%04x] <= %04x", $realtime, xosera.vram.address_in, xosera.vram.data_in);
-            end
-            else begin
-                flag <= 1;
-                last_rd_addr <= xosera.vram.address_in;
-            end
+    if (xosera.reg_interface.regs_vram_sel_o) begin
+        if (xosera.reg_interface.regs_wr_o) begin
+            $display("%0t Write VRAM[%04x] <= %04x", $realtime, xosera.vram.address_in, xosera.vram.data_in);
         end
-        else if (flag == 1) begin
-            $display("%0t Read VRAM[%04x] => %04x", $realtime, last_rd_addr, xosera.vram.data_out);
-            flag <= 0;
+        else begin
+            flag <= 1;
+            last_rd_addr <= xosera.vram.address_in;
         end
+    end
+    else if (flag == 1) begin
+        $display("%0t Read VRAM[%04x] => %04x", $realtime, last_rd_addr, xosera.vram.data_out);
+        flag <= 0;
     end
 end
 
@@ -424,20 +417,20 @@ end
 
 // NOTE: Horrible hacky Verilog string array to print register name (fixed 8 characters, and in reverse order).
 always @(posedge clk) begin
-    if (xosera.blitter.bus_write_strobe) begin
-        if (xosera.blitter.bus_bytesel) begin
-            $display("%0t BUS WRITE:  R[%1x:%s] <= __%02x", $realtime, xosera.blitter.bus_reg_num, regname(xosera.blitter.bus_reg_num), xosera.blitter.bus_data_byte);
+    if (xosera.reg_interface.bus_write_strobe) begin
+        if (xosera.reg_interface.bus_bytesel) begin
+            $display("%0t BUS WRITE:  R[%1x:%s] <= __%02x", $realtime, xosera.reg_interface.bus_reg_num, regname(xosera.reg_interface.bus_reg_num), xosera.reg_interface.bus_data_byte);
         end
         else begin
-            $display("%0t BUS WRITE:  R[%1x:%s] <= %02x__", $realtime, xosera.blitter.bus_reg_num, regname(xosera.blitter.bus_reg_num),xosera.blitter.bus_data_byte);
+            $display("%0t BUS WRITE:  R[%1x:%s] <= %02x__", $realtime, xosera.reg_interface.bus_reg_num, regname(xosera.reg_interface.bus_reg_num),xosera.reg_interface.bus_data_byte);
         end
     end
-    if (xosera.blitter.bus_read_strobe) begin
+    if (xosera.reg_interface.bus_read_strobe) begin
         if (xosera.bus_bytesel_i) begin
-            $display("%0t BUS READ:  R[%1x:%s] => __%02x", $realtime, xosera.blitter.bus_reg_num, regname(xosera.blitter.bus_reg_num),xosera.blitter.bus_data_o);
+            $display("%0t BUS READ:  R[%1x:%s] => __%02x", $realtime, xosera.reg_interface.bus_reg_num, regname(xosera.reg_interface.bus_reg_num),xosera.reg_interface.bus_data_o);
         end
         else begin
-            $display("%0t BUS READ:  R[%1x:%s] => %02x__", $realtime, xosera.blitter.bus_reg_num, regname(xosera.blitter.bus_reg_num), xosera.blitter.bus_data_o);
+            $display("%0t BUS READ:  R[%1x:%s] => %02x__", $realtime, xosera.reg_interface.bus_reg_num, regname(xosera.reg_interface.bus_reg_num), xosera.reg_interface.bus_data_o);
         end
     end
 end

--- a/rtl/xosera_iceb_stats.txt
+++ b/rtl/xosera_iceb_stats.txt
@@ -3,7 +3,7 @@ Package: oss-cad-suite-darwin-x64-20211008
 Yosys 0.10+14 (git sha1 772b9a108, x86_64-apple-darwin20.2-clang 10.0.0-4ubuntu1 -fPIC -Os)
 nextpnr-ice40 -- Next Generation Place and Route (Version b749ef5f)
 Info: Device utilisation:
-Info: 	         ICESTORM_LC:  2548/ 5280    48%
+Info: 	         ICESTORM_LC:  2396/ 5280    45%
 Info: 	        ICESTORM_RAM:    25/   30    83%
 Info: 	               SB_IO:    28/   96    29%
 Info: 	               SB_GB:     8/    8   100%
@@ -11,4 +11,4 @@ Info: 	        ICESTORM_PLL:     1/    1   100%
 Info: 	         SB_WARMBOOT:     1/    1   100%
 Info: 	      ICESTORM_SPRAM:     4/    4   100%
 
-Info: Max frequency for clock 'pclk': 33.92 MHz (PASS at 33.77 MHz)
+Info: Max frequency for clock 'pclk': 34.58 MHz (PASS at 33.77 MHz)

--- a/rtl/xosera_main.sv
+++ b/rtl/xosera_main.sv
@@ -54,41 +54,41 @@ module xosera_main(
            input  wire logic         reset_i                 // reset signal
        );
 
-logic        blit_vram_sel  /* verilator public */;     // blitter VRAM select
-logic        blit_xr_sel    /* verilator public */;     // blitter XR select
-logic        blit_wr        /* verilator public */;     // blitter VRAM/XR write
-logic  [3:0] blit_mask      /* verilator public */;     // 4 nibble write masks for vram
+logic        regs_vram_sel  /* verilator public */;     // register interface VRAM select
+logic        regs_xr_sel    /* verilator public */;     // register interface XR select
+logic        regs_wr        /* verilator public */;     // register interface VRAM/XR write
+logic  [3:0] regs_mask      /* verilator public */;     // 4 nibble write masks for vram
 
-logic [15:0] blit_addr      /* verilator public */;     // blitter VRAM/XR addr
-logic [15:0] blit_data_in   /* verilator public */;     // blitter VRAM/XR data read
-logic [15:0] blit_data_out  /* verilator public */;     // blitter bus VRAM/XR data write
+logic [15:0] regs_addr      /* verilator public */;     // register interface VRAM/XR addr
+logic [15:0] regs_data_in   /* verilator public */;     // register interface VRAM/XR data read
+logic [15:0] regs_data_out  /* verilator public */;     // register interface bus VRAM/XR data write
 
-logic blit_vgen_reg_sel     /* verilator public */;
-logic blit_vgen_reg_wr      /* verilator public */;
+logic regs_vgen_reg_sel     /* verilator public */;
+logic regs_vgen_reg_wr      /* verilator public */;
 
-logic blit_tilemem_sel      /* verilator public */;
-logic blit_tilemem_wr       /* verilator public */;
+logic regs_tilemem_sel      /* verilator public */;
+logic regs_tilemem_wr       /* verilator public */;
 
-logic blit_colormem_sel     /* verilator public */;
-logic blit_colormem_wr      /* verilator public */;
+logic regs_colormem_sel     /* verilator public */;
+logic regs_colormem_wr      /* verilator public */;
 
-logic blit_coppermem_sel    /* verilator public */;
-logic blit_coppermem_wr     /* verilator public */;
+logic regs_coppermem_sel    /* verilator public */;
+logic regs_coppermem_wr     /* verilator public */;
 
-logic blit_spritemem_sel    /* verilator public */;
-logic blit_spritemem_wr     /* verilator public */;
+logic regs_spritemem_sel    /* verilator public */;
+logic regs_spritemem_wr     /* verilator public */;
 
-assign  blit_vgen_reg_sel   = blit_xr_sel && !blit_addr[15];
-assign  blit_colormem_sel   = blit_xr_sel && blit_addr[15] && (blit_addr[13:12] == xv::XR_COLOR_MEM[13:12]);
-assign  blit_tilemem_sel    = blit_xr_sel && blit_addr[15] && (blit_addr[13:12] == xv::XR_TILE_MEM[13:12]);
-assign  blit_coppermem_sel  = blit_xr_sel && blit_addr[15] && (blit_addr[13:12] == xv::XR_COPPER_MEM[13:12]);
-assign  blit_spritemem_sel  = blit_xr_sel && blit_addr[15] && (blit_addr[13:12] == xv::XR_SPRITE_MEM[13:12]);
+assign  regs_vgen_reg_sel   = regs_xr_sel && !regs_addr[15];
+assign  regs_colormem_sel   = regs_xr_sel && regs_addr[15] && (regs_addr[13:12] == xv::XR_COLOR_MEM[13:12]);
+assign  regs_tilemem_sel    = regs_xr_sel && regs_addr[15] && (regs_addr[13:12] == xv::XR_TILE_MEM[13:12]);
+assign  regs_coppermem_sel  = regs_xr_sel && regs_addr[15] && (regs_addr[13:12] == xv::XR_COPPER_MEM[13:12]);
+assign  regs_spritemem_sel  = regs_xr_sel && regs_addr[15] && (regs_addr[13:12] == xv::XR_SPRITE_MEM[13:12]);
 
-assign  blit_vgen_reg_wr    = blit_vgen_reg_sel && blit_wr;
-assign  blit_tilemem_wr     = blit_tilemem_sel && blit_wr;
-assign  blit_colormem_wr    = blit_colormem_sel && blit_wr;
-assign  blit_spritemem_wr   = blit_spritemem_sel && blit_wr;
-assign  blit_coppermem_wr   = blit_coppermem_sel && blit_wr;
+assign  regs_vgen_reg_wr    = regs_vgen_reg_sel && regs_wr;
+assign  regs_tilemem_wr     = regs_tilemem_sel && regs_wr;
+assign  regs_colormem_wr    = regs_colormem_sel && regs_wr;
+assign  regs_spritemem_wr   = regs_spritemem_sel && regs_wr;
+assign  regs_coppermem_wr   = regs_coppermem_sel && regs_wr;
 
 // Copper
 logic [15:0] copp_wr_addr       /* verilator public */;
@@ -121,21 +121,21 @@ logic        xr_reg_wr_in;
 logic [4:0]  xr_reg_wr_addr_in;
 logic [15:0] xr_reg_wr_data_in;
 
-assign coppermem_wr_in          = blit_coppermem_wr  || copp_coppermem_wr;
-assign coppermem_wr_addr_in     = blit_coppermem_wr   ? blit_addr[10:0] : copp_wr_addr[10:0]; 
-assign coppermem_wr_data_in     = blit_coppermem_wr   ? blit_data_out   : copp_data_out;
+assign coppermem_wr_in          = regs_coppermem_wr  || copp_coppermem_wr;
+assign coppermem_wr_addr_in     = regs_coppermem_wr   ? regs_addr[10:0] : copp_wr_addr[10:0]; 
+assign coppermem_wr_data_in     = regs_coppermem_wr   ? regs_data_out   : copp_data_out;
 
-assign colormem_wr_in           = blit_colormem_wr || copp_colormem_wr;
-assign colormem_wr_addr_in      = blit_colormem_wr  ? blit_addr[7:0]  : copp_wr_addr[7:0]; 
-assign colormem_wr_data_in      = blit_colormem_wr  ? blit_data_out   : copp_data_out;
+assign colormem_wr_in           = regs_colormem_wr || copp_colormem_wr;
+assign colormem_wr_addr_in      = regs_colormem_wr  ? regs_addr[7:0]  : copp_wr_addr[7:0]; 
+assign colormem_wr_data_in      = regs_colormem_wr  ? regs_data_out   : copp_data_out;
 
-assign tilemem_wr_in            = blit_tilemem_wr    || copp_tilemem_wr;
-assign tilemem_wr_addr_in       = blit_tilemem_wr     ? blit_addr[11:0]  : copp_wr_addr[11:0]; 
-assign tilemem_wr_data_in       = blit_tilemem_wr     ? blit_data_out    : copp_data_out;
+assign tilemem_wr_in            = regs_tilemem_wr    || copp_tilemem_wr;
+assign tilemem_wr_addr_in       = regs_tilemem_wr     ? regs_addr[11:0]  : copp_wr_addr[11:0]; 
+assign tilemem_wr_data_in       = regs_tilemem_wr     ? regs_data_out    : copp_data_out;
 
-assign xr_reg_wr_in             = blit_vgen_reg_wr   || copp_vgen_reg_wr;
-assign xr_reg_wr_addr_in        = blit_vgen_reg_wr    ? blit_addr[4:0]   : copp_wr_addr[4:0];
-assign xr_reg_wr_data_in        = blit_vgen_reg_wr    ? blit_data_out    : copp_data_out;
+assign xr_reg_wr_in             = regs_vgen_reg_wr   || copp_vgen_reg_wr;
+assign xr_reg_wr_addr_in        = regs_vgen_reg_wr    ? regs_addr[4:0]   : copp_wr_addr[4:0];
+assign xr_reg_wr_data_in        = regs_vgen_reg_wr    ? regs_data_out    : copp_data_out;
 
 logic [10:0]    copper_pc;
 logic           coppermem_rd_en;
@@ -153,13 +153,13 @@ logic [15:0] vram_data_in   /* verilator public */;
 logic [15:0] vram_data_out  /* verilator public */;
 logic        vgen_vram_load;
 logic [15:0] vgen_vram_read;
-logic        blit_vram_load;
-logic [15:0] blit_vram_read;
+logic        regs_vram_load;
+logic [15:0] regs_vram_read;
 
 logic vgen_vram_sel;            // video vram select (read)
 logic [15:0] vgen_vram_addr;    // video vram addr
 logic [15:0] vgen_data_in;      // video vram read data
-logic [15:0] vgen_reg_data_out; // video data out for blitter reg reads
+logic [15:0] vgen_reg_data_out; // video data out for register interface reg reads
 
 logic  [3:0]    intr_mask;          // true for each enabled interrupt
 logic  [3:0]    intr_status;        // pending interrupt status
@@ -185,14 +185,14 @@ logic           dv_de_1;
 
 // audio generation (TODO)
 assign audio_l_o = dbug_cs_strobe;                    // TODO: audio
-assign audio_r_o = blit_xr_sel; //dbug_drive_bus;                    // TODO: audio
+assign audio_r_o = regs_xr_sel; //dbug_drive_bus;                    // TODO: audio
 
-assign vram_sel     = vgen_vram_sel ? 1'b1              : blit_vram_sel;
-assign vram_wr      = vgen_vram_sel ? 1'b0              : (blit_wr & blit_vram_sel);
-assign vram_mask    = vgen_vram_sel ? 4'b0000           : blit_mask;
-assign vram_addr    = vgen_vram_sel ? vgen_vram_addr    : blit_addr;
-assign vram_data_in = blit_data_out;
-assign blit_data_in = blit_vram_load ? vram_data_out    : blit_vram_read;
+assign vram_sel     = vgen_vram_sel ? 1'b1              : regs_vram_sel;
+assign vram_wr      = vgen_vram_sel ? 1'b0              : (regs_wr & regs_vram_sel);
+assign vram_mask    = vgen_vram_sel ? 4'b0000           : regs_mask;
+assign vram_addr    = vgen_vram_sel ? vgen_vram_addr    : regs_addr;
+assign vram_data_in = regs_data_out;
+assign regs_data_in = regs_vram_load ? vram_data_out    : regs_vram_read;
 assign vgen_data_in = vgen_vram_load ? vram_data_out    : vgen_vram_read;
 
 // save vgen value read from vram
@@ -208,17 +208,17 @@ end
 
 // save blit value read from vram
 always_ff @(posedge clk) begin
-    if (blit_vram_load) begin
-        blit_vram_read <= vram_data_out;
+    if (regs_vram_load) begin
+        regs_vram_read <= vram_data_out;
     end
-    blit_vram_load <= 1'b0; 
-    if (blit_vram_sel) begin
-        blit_vram_load <= ~blit_wr;
+    regs_vram_load <= 1'b0; 
+    if (regs_vram_sel) begin
+        regs_vram_load <= ~regs_wr;
     end
 end
 
-// blitter (really register logic for CPU access)
-blitter blitter(
+// register interface (really register logic for CPU access)
+reg_interface reg_interface(
     .clk(clk),
     .bus_cs_n_i(bus_cs_n_i),            // register select strobe
     .bus_rd_nwr_i(bus_rd_nwr_i),        // 0 = write, 1 = read
@@ -226,14 +226,14 @@ blitter blitter(
     .bus_bytesel_i(bus_bytesel_i),      // 0=even byte, 1=odd byte
     .bus_data_i(bus_data_i),            // 8-bit data bus input
     .bus_data_o(bus_data_o),            // 8-bit data bus output
-    .vgen_sel_i(vgen_vram_sel),         // blitter or vgen vram access this cycle
-    .blit_vram_sel_o(blit_vram_sel),    // blitter vram select
-    .blit_xr_sel_o(blit_xr_sel),        // blitter aux memory select
-    .blit_wr_o(blit_wr),                // blitter write
-    .blit_mask_o(blit_mask),            // vram nibble masks
-    .blit_addr_o(blit_addr),            // vram/aux address
-    .blit_data_i(blit_data_in),         // 16-bit word read from aux/vram
-    .blit_data_o(blit_data_out),        // 16-bit word write to aux/vram
+    .vgen_sel_i(vgen_vram_sel),         // register interface or vgen vram access this cycle
+    .regs_vram_sel_o(regs_vram_sel),    // register interface vram select
+    .regs_xr_sel_o(regs_xr_sel),        // register interface aux memory select
+    .regs_wr_o(regs_wr),                // register interface write
+    .regs_mask_o(regs_mask),            // vram nibble masks
+    .regs_addr_o(regs_addr),            // vram/aux address
+    .regs_data_i(regs_data_in),         // 16-bit word read from aux/vram
+    .regs_data_o(regs_data_out),        // 16-bit word write to aux/vram
     .xr_data_i(vgen_reg_data_out),
     .reconfig_o(reconfig_o),
     .boot_select_o(boot_select_o),
@@ -246,7 +246,7 @@ blitter blitter(
 //  video generation
 video_gen video_gen(
     .vgen_reg_wr_i(xr_reg_wr_in),
-    .vgen_reg_num_r_i(blit_addr[4:0]),
+    .vgen_reg_num_r_i(regs_addr[4:0]),
     .vgen_reg_num_w_i(xr_reg_wr_addr_in),
     .vgen_reg_data_i(xr_reg_wr_data_in),
     .vgen_reg_data_o(vgen_reg_data_out),
@@ -312,9 +312,9 @@ spritemem spritemem(
     .rd_address_i(spritemem_addr),
     .rd_data_o(spritemem_data_out),
     .wr_clk(clk),
-    .wr_en_i(blit_spritemem_wr),
-    .wr_address_i(blit_addr[7:0]),
-    .wr_data_i(blit_data_out)
+    .wr_en_i(regs_spritemem_wr),
+    .wr_address_i(regs_addr[7:0]),
+    .wr_data_i(regs_data_out)
 );
 
 // Copper
@@ -327,13 +327,13 @@ copper copper(
     .coppermem_rd_addr_o(copper_pc),
     .coppermem_rd_en_o(coppermem_rd_en),
     .coppermem_rd_data_i(coppermem_rd_data_out),
-    .blit_xr_reg_sel_i(blit_vgen_reg_sel),
-    .blit_tilemem_sel_i(blit_tilemem_sel),
-    .blit_colormem_sel_i(blit_colormem_sel),
-    .blit_coppermem_sel_i(blit_coppermem_sel),
-    .copp_reg_wr_i(blit_vgen_reg_wr),
-    .copp_reg_num_i(blit_addr[3:0]),
-    .copp_reg_data_i(blit_data_out),
+    .regs_xr_reg_sel_i(regs_vgen_reg_sel),
+    .regs_tilemem_sel_i(regs_tilemem_sel),
+    .regs_colormem_sel_i(regs_colormem_sel),
+    .regs_coppermem_sel_i(regs_coppermem_sel),
+    .copp_reg_wr_i(regs_vgen_reg_wr),
+    .copp_reg_num_i(regs_addr[3:0]),
+    .copp_reg_data_i(regs_data_out),
     .h_count_i(video_h_count),
     .v_count_i(video_v_count)
 );

--- a/rtl/xosera_upd_stats.txt
+++ b/rtl/xosera_upd_stats.txt
@@ -3,7 +3,7 @@ Package: oss-cad-suite-darwin-x64-20211008
 Yosys 0.10+14 (git sha1 772b9a108, x86_64-apple-darwin20.2-clang 10.0.0-4ubuntu1 -fPIC -Os)
 nextpnr-ice40 -- Next Generation Place and Route (Version b749ef5f)
 Info: Device utilisation:
-Info: 	         ICESTORM_LC:  2337/ 5280    44%
+Info: 	         ICESTORM_LC:  2331/ 5280    44%
 Info: 	        ICESTORM_RAM:    25/   30    83%
 Info: 	               SB_IO:    36/   96    37%
 Info: 	               SB_GB:     8/    8   100%
@@ -11,4 +11,4 @@ Info: 	        ICESTORM_PLL:     1/    1   100%
 Info: 	         SB_WARMBOOT:     1/    1   100%
 Info: 	      ICESTORM_SPRAM:     4/    4   100%
 
-Info: Max frequency for clock 'pclk': 35.18 MHz (PASS at 33.77 MHz)
+Info: Max frequency for clock 'pclk': 34.50 MHz (PASS at 33.77 MHz)

--- a/rtl/xosera_upd_stats.txt
+++ b/rtl/xosera_upd_stats.txt
@@ -3,7 +3,7 @@ Package: oss-cad-suite-darwin-x64-20211008
 Yosys 0.10+14 (git sha1 772b9a108, x86_64-apple-darwin20.2-clang 10.0.0-4ubuntu1 -fPIC -Os)
 nextpnr-ice40 -- Next Generation Place and Route (Version b749ef5f)
 Info: Device utilisation:
-Info: 	         ICESTORM_LC:  2458/ 5280    46%
+Info: 	         ICESTORM_LC:  2337/ 5280    44%
 Info: 	        ICESTORM_RAM:    25/   30    83%
 Info: 	               SB_IO:    36/   96    37%
 Info: 	               SB_GB:     8/    8   100%
@@ -11,4 +11,4 @@ Info: 	        ICESTORM_PLL:     1/    1   100%
 Info: 	         SB_WARMBOOT:     1/    1   100%
 Info: 	      ICESTORM_SPRAM:     4/    4   100%
 
-Info: Max frequency for clock 'pclk': 34.93 MHz (PASS at 33.77 MHz)
+Info: Max frequency for clock 'pclk': 35.18 MHz (PASS at 33.77 MHz)


### PR DESCRIPTION
Remove init state machine and rename current blitter module reg_interface (which is more accurate).  Also change blit_ signals to regs_. There is no "clear screen" at init now, so without CPU you will see colorful garbage (but simulation fills with TESTPATTERN).  This change also eases timing a bit (often 1st attempt from nextpnr-ice40).