### PR TITLE
Fix a tiny buglet in copper

### DIFF
--- a/copper/copper_test_m68k/xosera_copper_test.c
+++ b/copper/copper_test_m68k/xosera_copper_test.c
@@ -31,7 +31,6 @@
 #include <sdfat.h>
 
 #include "xosera_m68k_api.h"
-#include "xosera_m68k_copper.h"
 
 const uint8_t  copper_list_len = 26;
 const uint16_t copper_list[] = {

--- a/rtl/copper.sv
+++ b/rtl/copper.sv
@@ -433,9 +433,11 @@ always_ff @(posedge clk) begin
                                 end
                             end
                             default: begin
-                                // illegal instruction; do nothing
-                                copper_ex_state <= STATE_INIT;
+                                // illegal instruction; just setup fetch for 
+                                // next instruction
                                 copper_pc       <= copper_pc + 1;
+                                copper_ex_state <= STATE_WAIT;
+                                ram_rd_strobe   <= 1'b1;
                             end
                         endcase // Instruction                  
                     end


### PR DESCRIPTION
Fix two things:

* Illegal instruction in copper should be the same number of cycles as
  regular instructions (i.e. don't go back to INIT after illegal insn).
* Remove no-longer-present header from copper demo