### PR TITLE
Revert to 16-bit addressing for copper PC

### DIFF
--- a/copper/copper_asm/copper.casm
+++ b/copper/copper_asm/copper.casm
@@ -9,7 +9,7 @@
 ; This is for use with customasm: https://github.com/hlorenzi/customasm
 ; See also `example.asm`.
 
-#bits 32
+#bits 16
 #subruledef reg {
     VID_CTRL        => 0x00
     COPP_CTRL       => 0x01
@@ -39,7 +39,7 @@
     wait  {x: u11},    {y: u11},    {flags: u4} => 0b0000 @ 0b0     @ y`11    @ 0b0     @ x`11    @ flags`4
     skip  {x: u11},    {y: u11}                 => 0b0010 @ 0b0     @ y`11    @ 0b0     @ x`11    @ 0b0000
     skip  {x: u11},    {y: u11},    {flags: u4} => 0b0010 @ 0b0     @ y`11    @ 0b0     @ x`11    @ flags`4
-    jmp   {addr: u10}                           => 0b0100 @ 0b00    @ addr`10 @ 0b0000000000000000
+    jmp   {addr: u11}                           => 0b0100 @ 0b00    @ addr`10 @ 0b0000000000000000
     mover {r: reg},    {data: u16}              => 0b1001 @ 0b0000  @ r`8     @ data`16
     mover {addr: u8},  {data: u16}              => 0b1001 @ 0b0000  @ addr`8 @ data`16
     movef {addr: u12}, {data: u16}              => 0b1010 @ addr`12 @ data`16

--- a/copper/copper_test_m68k/xosera_copper_test.c
+++ b/copper/copper_test_m68k/xosera_copper_test.c
@@ -41,9 +41,9 @@ const uint16_t copper_list[] = {
 
     // copperlist:
     0x20a0, 0x0002, //     skip  0, 160, 0b00010  ; Skip next if we've hit line 160
-    0x400a, 0x0000, //     jmp   .gored           ; ... else, jump to set red
+    0x4014, 0x0000, //     jmp   .gored           ; ... else, jump to set red
     0x2140, 0x0002, //     skip  0, 320, 0b00010  ; Skip next if we've hit line 320
-    0x4007, 0x0000, //     jmp   .gogreen         ; ... else jump to set green
+    0x400e, 0x0000, //     jmp   .gogreen         ; ... else jump to set green
     0xb000, 0x000f, //     movep 0x000F, 0        ; Make background blue
     0xb00a, 0x0007, //     movep 0x0007, 0xA      ; Make foreground dark blue
     0x0000, 0x0003, //     nextf                  ; and we're done for this frame

--- a/rtl/copper.sv
+++ b/rtl/copper.sv
@@ -110,9 +110,10 @@
 //          Skip if a given screen position has been reached.
 //
 //
-//      JMP   - [0100 ooAA AAAA AAAA],[oooo oooo oooo oooo]
+//      JMP   - [0100 oAAA AAAA AAA0],[oooo oooo oooo oooo]
 //
 //          Jump to the given copper RAM address.
+//          Must be on a 32-bit boundary.
 //
 //
 //      MOVER - [1001 FFFF AAAA AAAA],[DDDD DDDD DDDD DDDD]
@@ -245,7 +246,7 @@ logic  [3:0]  opcode;
 
 assign ignore_v                 = r_insn[0];
 assign ignore_h                 = r_insn[1];
-assign copper_pc_jmp            = r_insn[25:16];
+assign copper_pc_jmp            = r_insn[26:17];
 assign move_data                = r_insn[15:0];
 assign move_r_p_addr            = r_insn[23:16];
 assign move_f_addr              = r_insn[27:16];


### PR DESCRIPTION
As discussed with @XarkLabs on Discord, this PR reverts copper PC to using 16-bit addressing in `JUMP` instructions.

Internally, the copper still utilises 32-bit addressing for the PC, however this change makes it such that copper memory is always addressed in terms of 16-bit words from the point of view of both CPU and Copper code.

