### PR TITLE
Make TILEMEM address 13-bit in copper

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -522,7 +522,7 @@ detailed below, along with the binary format.
 The `MOVE` instruction is actually subdivided into four specific types of move, as detailed
 below.
 
-**`WAIT` - [0000 oYYY YYYY YYYY],[oXXX XXXX XXXX FFFF]**
+**`WAIT` - [000o oYYY YYYY YYYY],[oXXX XXXX XXXX FFFF]**
 
 Wait for a given screen position to be reached (or exceeded).
 
@@ -537,7 +537,7 @@ If both horizontal and vertical ignore flags are set, this instruction will wait
 indefinitely (until the end of the frame). This can be used as a special "wait for
 end of frame" instruction.
 
-**`SKIP` - [0010 oYYY YYYY YYYY],[oXXX XXXX XXXX FFFF]**
+**`SKIP` - [001o oYYY YYYY YYYY],[oXXX XXXX XXXX FFFF]**
 
 Skip the next instruction if a given screen position has been reached.
 
@@ -552,23 +552,23 @@ If both horizontal and vertical ignore flags are set, this instruction will **al
 skip the next instruction. While not especially useful in its own right, this can come
 in handy in conjunction with in-place code modification.
 
-**`JMP` - [0100 oAAA AAAA AAAA],[oooo oooo oooo oooo]**
+**`JMP` - [010o oAAA AAAA AAAA],[oooo oooo oooo oooo]**
 
 Jump to the given copper RAM address.
 
-**`MOVER` - [1001 FFFF AAAA AAAA],[DDDD DDDD DDDD DDDD]**
+**`MOVER` - [011o FFFF AAAA AAAA],[DDDD DDDD DDDD DDDD]**
 
 Move 16-bit data to XR register specified by 8-bit address.
 
-**`MOVEF` - [1010 AAAA AAAA AAAA],[DDDD DDDD DDDD DDDD]**
+**`MOVEF` - [100A AAAA AAAA AAAA],[DDDD DDDD DDDD DDDD]**
 
 Move 16-bit data to `XR_TILE_MEM` (or 'font') memory.
 
-**`MOVEP` - [1011 oooo AAAA AAAA],[DDDD DDDD DDDD DDDD]**
+**`MOVEP` - [101o oooo AAAA AAAA],[DDDD DDDD DDDD DDDD]**
 
 Move 16-bit data to `XR_COLOR_MEM` (or 'palette') memory.
 
-**`MOVEC` - [1100 oAAA AAAA AAAA],[DDDD DDDD DDDD DDDD]**
+**`MOVEC` - [110o oAAA AAAA AAAA],[DDDD DDDD DDDD DDDD]**
 
 Move 16-bit data to `XR_COPPER_MEM` memory.
 

--- a/copper/copper_asm/copper.casm
+++ b/copper/copper_asm/copper.casm
@@ -40,11 +40,12 @@
     skip  {x: u11},    {y: u11}                 => 0b0010 @ 0b0     @ y`11    @ 0b0     @ x`11    @ 0b0000
     skip  {x: u11},    {y: u11},    {flags: u4} => 0b0010 @ 0b0     @ y`11    @ 0b0     @ x`11    @ flags`4
     jmp   {addr: u11}                           => 0b0100 @ 0b00    @ addr`10 @ 0b0000000000000000
-    mover {r: reg},    {data: u16}              => 0b1001 @ 0b0000  @ r`8     @ data`16
-    mover {addr: u8},  {data: u16}              => 0b1001 @ 0b0000  @ addr`8 @ data`16
-    movef {addr: u12}, {data: u16}              => 0b1010 @ addr`12 @ data`16
-    movep {addr: u8},  {data: u16}              => 0b1011 @ 0b0000  @ addr`8  @ data`16
+    mover {r: reg},    {data: u16}              => 0b0110 @ 0b0000  @ r`8     @ data`16
+    mover {addr: u8},  {data: u16}              => 0b0110 @ 0b0000  @ addr`8 @ data`16
+    movef {addr: u12}, {data: u16}              => 0b1000 @ addr`12 @ data`16
+    movep {addr: u8},  {data: u16}              => 0b1010 @ 0b0000  @ addr`8  @ data`16
     movec {addr: u11}, {data: u16}              => 0b1100 @ 0b0     @ addr`11 @ data`16
+    movet {addr: u11}, {data: u16}              => 0b111  @ addr`13 @ data`16
 
     ; nextf (wait next frame) is a pseudo-instruction, 
     ; it just generates a wait with both X and Y ignored.

--- a/copper/copper_asm/crop.asm
+++ b/copper/copper_asm/crop.asm
@@ -1,0 +1,8 @@
+#include "copper.casm"
+
+copperlist:
+    wait  0, 40, 0b000010               ; Wait for line 40, ignore X position
+    mover PA_GFX_CTRL, 0x75             ; Move 0x75 to GFX control
+    wait  0, 440, 0b000010              ; Wait for line 440, ignore X position
+    mover PA_GFX_CTRL, 0xF5             ; Move 0xF5 to GFX control
+    wait  0, 0, 0b000011                ; Wait for next frame

--- a/copper/copper_test_m68k/xosera_copper_test.c
+++ b/copper/copper_test_m68k/xosera_copper_test.c
@@ -44,16 +44,16 @@ const uint16_t copper_list[] = {
     0x4014, 0x0000, //     jmp   .gored           ; ... else, jump to set red
     0x2140, 0x0002, //     skip  0, 320, 0b00010  ; Skip next if we've hit line 320
     0x400e, 0x0000, //     jmp   .gogreen         ; ... else jump to set green
-    0xb000, 0x000f, //     movep 0x000F, 0        ; Make background blue
-    0xb00a, 0x0007, //     movep 0x0007, 0xA      ; Make foreground dark blue
+    0xa000, 0x000f, //     movep 0x000F, 0        ; Make background blue
+    0xa00a, 0x0004, //     movep 0x0004, 0xA      ; Make foreground dark blue
     0x0000, 0x0003, //     nextf                  ; and we're done for this frame
                     // .gogreen:
-    0xb000, 0x00f0, //     movep 0x00F0, 0        ; Make background green
-    0xb00a, 0x0070, //     movep 0x0070, 0xA       ; Make foreground dark green 
+    0xa000, 0x00f0, //     movep 0x00F0, 0        ; Make background green
+    0xa00a, 0x0040, //     movep 0x0040, 0xA      ; Make foreground dark green 
     0x4000, 0x0000, //     jmp   copperlist       ; and restart
                     // .gored:
-    0xb000, 0x0f00, //     movep 0x0F00, 0        ; Make background red
-    0xb00a, 0x0700, //     movep 0x0700, 0xA      ; Make foreground dark red
+    0xa000, 0x0f00, //     movep 0x0F00, 0        ; Make background red
+    0xa00a, 0x0400, //     movep 0x0400, 0xA      ; Make foreground dark red
     0x4000, 0x0000  //     jmp   copperlist       ; and restart
     
     /* This is a saner way to do the above!

--- a/copper/splitscreen_test_m68k/splitscreen_test_m68k.c
+++ b/copper/splitscreen_test_m68k/splitscreen_test_m68k.c
@@ -39,12 +39,12 @@ volatile uint32_t optguard;
 // Copper list
 const uint8_t  copper_list_len = 14;
 const uint16_t copper_list[] = {
-    0x9010, 0x0055,     // mover 0055, PA_GFX_CTRL       ; First half of screen in 4-bpp + Hx2 + Vx2
-    0xb00f, 0x0ec6,     // movep 0x0ec6, 0xf             ; Palette entry 0xf from tut bitmap
+    0x6010, 0x0055,     // mover 0055, PA_GFX_CTRL       ; First half of screen in 4-bpp + Hx2 + Vx2
+    0xa00f, 0x0ec6,     // movep 0x0ec6, 0xf             ; Palette entry 0xf from tut bitmap
     0x00f0, 0x0002,     // wait  0, 240, 0b00010         ; Wait for line 240, H position ignored
-    0x9015, 0x3e80,     // mover 0x3e80, PA_LINE_ADDR    ; Line start now at 16000
-    0x9010, 0x0040,     // mover 0x0040, PA_GFX_CTRL     ; 1-bpp + Hx1 + Vx1
-    0xb00f, 0x0fff,     // movep 0x0fff, 0xf             ; Palette entry 0xf to white for 1bpp bitmap
+    0x6015, 0x3e80,     // mover 0x3e80, PA_LINE_ADDR    ; Line start now at 16000
+    0x6010, 0x0040,     // mover 0x0040, PA_GFX_CTRL     ; 1-bpp + Hx1 + Vx1
+    0xa00f, 0x0fff,     // movep 0x0fff, 0xf             ; Palette entry 0xf to white for 1bpp bitmap
     0x0000, 0x0003      // nextf                         ; Wait for next frame
 };
 

--- a/xosera_m68k_api/xosera_m68k_defs.h
+++ b/xosera_m68k_api/xosera_m68k_defs.h
@@ -122,9 +122,9 @@
 #define COP_SKIP_V(v_pos)           (0x20000002 | XB_((uint32_t)(v_pos), 26, 16))
 #define COP_SKIP_F()                (0x20000003 | XB_((uint32_t)(0), 14, 4))
 #define COP_JUMP(cop_addr)          (0x40000000 | XB_((uint32_t)(cop_addr), 26, 16))
-#define COP_MOVER(val16, xreg)      (0x90000000 | XB_((uint32_t)(XR_##xreg), 23, 16) | ((uint16)(val16)))
-#define COP_MOVEF(val16, tile_addr) (0xa0000000 | XB_((uint32_t)(tile_addr), 27, 16) | ((uint16)(val16)))
-#define COP_MOVEP(rgb16, color_num) (0xB0000000 | XB_((uint32_t)(color_num), 23, 16) | ((uint16)(rgb16)))
+#define COP_MOVER(val16, xreg)      (0x60000000 | XB_((uint32_t)(XR_##xreg), 23, 16) | ((uint16)(val16)))
+#define COP_MOVEF(val16, tile_addr) (0x80000000 | XB_((uint32_t)(tile_addr), 28, 16) | ((uint16)(val16)))
+#define COP_MOVEP(rgb16, color_num) (0xA0000000 | XB_((uint32_t)(color_num), 23, 16) | ((uint16)(rgb16)))
 #define COP_MOVEC(val16, cop_addr)  (0xC0000000 | XB_((uint32_t)(cop_addr), 26, 16) | ((uint16)(val16)))
 
 // TODO blit and polydraw


### PR DESCRIPTION
Support 13-bit addresses for TILEMEM in copper.

* **Breaking Change** - Copper opcodes reorganised (reduced to 3-bit).
* MOVEF address range expanded with newly-unused bit
* Copper assembler updated with new opcodes
* Copper example code updated with new opcodes
* m68k-api macros updated with new opcodes
* Copper comments updated 
* REFERENCE.md updated