### PR TITLE
Give palette indices 9 bits

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -569,7 +569,7 @@ Move 16-bit data to XR register specified by 8-bit address.
 
 Move 16-bit data to `XR_TILE_MEM` (or 'font') memory.
 
-**`MOVEP` - [101o oooo AAAA AAAA],[DDDD DDDD DDDD DDDD]**
+**`MOVEP` - [101o oooA AAAA AAAA],[DDDD DDDD DDDD DDDD]**
 
 Move 16-bit data to `XR_COLOR_MEM` (or 'palette') memory.
 
@@ -596,7 +596,7 @@ ___
 With the available `MOVE` variants, the copper can directly MOVE to the following:
 
 - Any Xosera XR register (including the copper control register)
-- Xosera tile memory (or font memory - #TODO: except last 1KW, this limitation may be removed in the future).
+- Xosera tile memory (or font memory).
 - Xosera color memory
 - Xosera copper memory
 
@@ -632,3 +632,8 @@ for details of use.
 A simple executable ruby script, `bin2c.rb` is also provided in that directory. This is a simple
 utility that takes assembled copper binaries and outputs them as a C array (with associated size)
 for direct embedding into C code.
+
+Additionally, there are a bunch of handy C macros (in the Xosera m68k API headers) that facilitate
+writing readable copper code directly in C source code. The included examples (in `copper` directory)
+demonstrate the different ways of embedding copper code in C source.
+

--- a/copper/copper_asm/copper.casm
+++ b/copper/copper_asm/copper.casm
@@ -43,7 +43,7 @@
     mover {r: reg},    {data: u16}              => 0b0110 @ 0b0000  @ r`8     @ data`16
     mover {addr: u8},  {data: u16}              => 0b0110 @ 0b0000  @ addr`8 @ data`16
     movef {addr: u12}, {data: u16}              => 0b1000 @ addr`12 @ data`16
-    movep {addr: u8},  {data: u16}              => 0b1010 @ 0b0000  @ addr`8  @ data`16
+    movep {addr: u9},  {data: u16}              => 0b1010 @ 0b000   @ addr`9  @ data`16
     movec {addr: u11}, {data: u16}              => 0b1100 @ 0b0     @ addr`11 @ data`16
     movet {addr: u11}, {data: u16}              => 0b111  @ addr`13 @ data`16
 

--- a/rtl/copper.sv
+++ b/rtl/copper.sv
@@ -126,7 +126,7 @@
 //          Move 16-bit data to XR_TILE_MEM memory.
 //
 //
-//      MOVEP - [101o oooo AAAA AAAA],[DDDD DDDD DDDD DDDD]
+//      MOVEP - [101o oooA AAAA AAAA],[DDDD DDDD DDDD DDDD]
 //
 //          Move 16-bit data to XR_COLOR_MEM (palette) memory.
 //
@@ -235,7 +235,8 @@ logic          ignore_v;
 logic          ignore_h;
 logic [C_PC:0] copper_pc_jmp;
 logic [15:0]   move_data;
-logic  [7:0]   move_r_p_addr;
+logic  [7:0]   move_r_addr;
+logic  [8:0]   move_p_addr;
 logic [12:0]   move_f_addr;
 logic [10:0]   move_c_addr_v_pos;
 logic [10:0]   h_pos;
@@ -245,7 +246,8 @@ assign ignore_v                 = r_insn[0];
 assign ignore_h                 = r_insn[1];
 assign copper_pc_jmp            = r_insn[26:17];
 assign move_data                = r_insn[15:0];
-assign move_r_p_addr            = r_insn[23:16];
+assign move_r_addr              = r_insn[23:16];
+assign move_p_addr              = r_insn[24:16];
 assign move_f_addr              = r_insn[28:16];
 assign move_c_addr_v_pos        = r_insn[26:16];
 assign h_pos                    = r_insn[14:4];
@@ -436,7 +438,7 @@ always_ff @(posedge clk) begin
                             // mover
                             xr_wr_en                <= 1'b1;
                             ram_wr_addr_out[15:8]   <= 8'h0;
-                            ram_wr_addr_out[7:0]    <= move_r_p_addr;
+                            ram_wr_addr_out[7:0]    <= move_r_addr;
                             ram_wr_data_out         <= move_data;
 
                             // Setup fetch next instruction
@@ -457,8 +459,8 @@ always_ff @(posedge clk) begin
                         INSN_MOVEP: begin
                             // movep
                             xr_wr_en                <= 1'b1;
-                            ram_wr_addr_out[15:8]   <= xv::XR_COLOR_MEM[15:8];
-                            ram_wr_addr_out[7:0]    <= move_r_p_addr;
+                            ram_wr_addr_out[15:9]   <= xv::XR_COLOR_MEM[15:9];
+                            ram_wr_addr_out[8:0]    <= move_p_addr;
                             ram_wr_data_out         <= move_data;
 
                             // Setup fetch next instruction


### PR DESCRIPTION
Just adding an extra bit for palette addresses.

Copper asm, docs & comments updated. Examples don't need to be changed as MOVEP always filled unused address bits with zero anyway. 

Timing still seems good (not that I particularly expected this to affect it, but one never knows 😅):

```
=== Synthesizing 7 bitstreams and determine best fMAX
1	upduino/xosera_upd_vga_848x480_1.asc:	Max frequency for clock 'pclk': 39.12 MHz (PASS at 33.77 MHz)
2	upduino/xosera_upd_vga_848x480_2.asc:	Max frequency for clock 'pclk': 36.78 MHz (PASS at 33.77 MHz)
3	upduino/xosera_upd_vga_848x480_3.asc:	Max frequency for clock 'pclk': 36.79 MHz (PASS at 33.77 MHz)
4	upduino/xosera_upd_vga_848x480_4.asc:	Max frequency for clock 'pclk': 41.52 MHz (PASS at 33.77 MHz)
5	upduino/xosera_upd_vga_848x480_5.asc:	Max frequency for clock 'pclk': 38.65 MHz (PASS at 33.77 MHz)
6	upduino/xosera_upd_vga_848x480_6.asc:	Max frequency for clock 'pclk': 39.20 MHz (PASS at 33.77 MHz)
7	upduino/xosera_upd_vga_848x480_7.asc:	Max frequency for clock 'pclk': 38.61 MHz (PASS at 33.77 MHz)
=== fMAX after 7 runs: ===
min =  36.78
avg =  38.6671  <==
max =  41.52
=== Using bitstream from NextPNR run 4 with best result 41.52 MHz
```