### PR TITLE
Optional support for rosco_m68k Pro in Xosera API

### DIFF
--- a/copper/copper_test_m68k/Makefile
+++ b/copper/copper_test_m68k/Makefile
@@ -46,6 +46,10 @@ KERMIT=kermit
 SERIAL?=/dev/modem
 BAUD?=9600
 
+ifeq ($(ROSCO_M68K_PRO),true)
+DEFINES+=-DROSCO_M68K_PRO
+endif
+
 # Output config (assume name of directory)
 PROGRAM_BASENAME=$(shell basename $(CURDIR))
 

--- a/copper/crop_test_m68k/Makefile
+++ b/copper/crop_test_m68k/Makefile
@@ -46,6 +46,10 @@ KERMIT=kermit
 SERIAL?=/dev/modem
 BAUD?=9600
 
+ifeq ($(ROSCO_M68K_PRO),true)
+DEFINES+=-DROSCO_M68K_PRO
+endif
+
 # Output config (assume name of directory)
 PROGRAM_BASENAME=$(shell basename $(CURDIR))
 

--- a/copper/splitscreen_test_m68k/Makefile
+++ b/copper/splitscreen_test_m68k/Makefile
@@ -46,6 +46,10 @@ KERMIT=kermit
 SERIAL?=/dev/modem
 BAUD?=9600
 
+ifeq ($(ROSCO_M68K_PRO),true)
+DEFINES+=-DROSCO_M68K_PRO
+endif
+
 # Output config (assume name of directory)
 PROGRAM_BASENAME=$(shell basename $(CURDIR))
 

--- a/xosera_ansiterm_m68k/Makefile
+++ b/xosera_ansiterm_m68k/Makefile
@@ -59,6 +59,10 @@ KERMIT=kermit
 SERIAL?=/dev/modem
 BAUD?=9600
 
+ifeq ($(ROSCO_M68K_PRO),true)
+DEFINES+=-DROSCO_M68K_PRO
+endif
+
 # Output config (assume name of directory)
 PROGRAM_BASENAME=$(shell basename $(CURDIR))
 

--- a/xosera_demo_m68k/Makefile
+++ b/xosera_demo_m68k/Makefile
@@ -46,6 +46,10 @@ KERMIT=kermit
 SERIAL?=/dev/modem
 BAUD?=9600
 
+ifeq ($(ROSCO_M68K_PRO),true)
+DEFINES+=-DROSCO_M68K_PRO
+endif
+
 # Output config (assume same as name of directory)
 PROGRAM_BASENAME=$(shell basename $(CURDIR))
 

--- a/xosera_gfx_test/Makefile
+++ b/xosera_gfx_test/Makefile
@@ -46,6 +46,10 @@ KERMIT=kermit
 SERIAL?=/dev/modem
 BAUD?=9600
 
+ifeq ($(ROSCO_M68K_PRO),true)
+DEFINES+=-DROSCO_M68K_PRO
+endif
+
 # Output config (assume name of directory)
 PROGRAM_BASENAME=$(shell basename $(CURDIR))
 

--- a/xosera_m68k_api/xosera_m68k_api.h
+++ b/xosera_m68k_api/xosera_m68k_api.h
@@ -69,6 +69,14 @@ void xv_copy_from_vram(uint32_t vram_source, uint16_t * dest, uint32_t numbytes)
 
 #include "xosera_m68k_defs.h"
 
+#ifdef ROSCO_M68K_PRO
+#define MOVEW "move.w"
+#define MOVEL "move.l"
+#else
+#define MOVEW "movep.w"
+#define MOVEL "movep.l"
+#endif
+
 // C preprocessor "stringify" to embed #define into inline asm string
 #define _XM_STR(s) #s
 #define XM_STR(s)  _XM_STR(s)
@@ -120,7 +128,7 @@ extern volatile xmreg_t * const xosera_ptr;
     {                                                                                                                  \
         (void)(XM_##xmreg);                                                                                            \
         uint16_t uval16 = (word_value);                                                                                \
-        __asm__ __volatile__("movep.w %[src]," XM_STR(XM_##xmreg) "(%[ptr])"                                           \
+        __asm__ __volatile__(MOVEW " %[src]," XM_STR(XM_##xmreg) "(%[ptr])"                                            \
                              :                                                                                         \
                              : [src] "d"(uval16), [ptr] "a"(xosera_ptr)                                                \
                              :);                                                                                       \
@@ -132,7 +140,7 @@ extern volatile xmreg_t * const xosera_ptr;
     {                                                                                                                  \
         (void)(XM_##xmreg);                                                                                            \
         uint32_t uval32 = (long_value);                                                                                \
-        __asm__ __volatile__("movep.l %[src]," XM_STR(XM_##xmreg) "(%[ptr])"                                           \
+        __asm__ __volatile__(MOVEL " %[src]," XM_STR(XM_##xmreg) "(%[ptr])"                                            \
                              :                                                                                         \
                              : [src] "d"(uval32), [ptr] "a"(xosera_ptr)                                                \
                              :);                                                                                       \
@@ -145,7 +153,7 @@ extern volatile xmreg_t * const xosera_ptr;
         uint16_t uval16 = (word_value);                                                                                \
         if (__builtin_constant_p((XR_##xreg)) && __builtin_constant_p((word_value)))                                   \
         {                                                                                                              \
-            __asm__ __volatile__("movep.l %[rxav]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; "                                   \
+            __asm__ __volatile__(MOVEL " %[rxav]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; "                                    \
                                  :                                                                                     \
                                  : [rxav] "d"(((XR_##xreg) << 16) | (uint16_t)((word_value))), [ptr] "a"(xosera_ptr)   \
                                  :);                                                                                   \
@@ -153,7 +161,7 @@ extern volatile xmreg_t * const xosera_ptr;
         else                                                                                                           \
         {                                                                                                              \
             __asm__ __volatile__(                                                                                      \
-                "movep.w %[rxa]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; movep.w %[src]," XM_STR(XM_XR_DATA) "(%[ptr])"        \
+                MOVEW " %[rxa]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; " MOVEW " %[src]," XM_STR(XM_XR_DATA) "(%[ptr])"       \
                 :                                                                                                      \
                 : [rxa] "d"((XR_##xreg)), [src] "d"(uval16), [ptr] "a"(xosera_ptr)                                     \
                 :);                                                                                                    \
@@ -167,7 +175,7 @@ extern volatile xmreg_t * const xosera_ptr;
         uint16_t umem16 = (xrmem);                                                                                     \
         uint16_t uval16 = (word_value);                                                                                \
         __asm__ __volatile__(                                                                                          \
-            "movep.w %[xra]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; movep.w %[src]," XM_STR(XM_XR_DATA) "(%[ptr])"            \
+            MOVEW " %[xra]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; " MOVEW " %[src]," XM_STR(XM_XR_DATA) "(%[ptr])"           \
             :                                                                                                          \
             : [xra] "d"(umem16), [src] "d"(uval16), [ptr] "a"(xosera_ptr)                                              \
             :);                                                                                                        \
@@ -186,7 +194,7 @@ extern volatile xmreg_t * const xosera_ptr;
     ({                                                                                                                 \
         (void)(XM_##xmreg);                                                                                            \
         uint16_t word_value;                                                                                           \
-        __asm__ __volatile__("movep.w " XM_STR(XM_##xmreg) "(%[ptr]),%[dst]"                                           \
+        __asm__ __volatile__(MOVEW " " XM_STR(XM_##xmreg) "(%[ptr]),%[dst]"                                            \
                              : [dst] "=d"(word_value)                                                                  \
                              : [ptr] "a"(xosera_ptr)                                                                   \
                              :);                                                                                       \
@@ -197,7 +205,7 @@ extern volatile xmreg_t * const xosera_ptr;
     ({                                                                                                                 \
         (void)(XM_##xmreg);                                                                                            \
         uint32_t long_value;                                                                                           \
-        __asm__ __volatile__("movep.l " XM_STR(XM_##xmreg) "(%[ptr]),%[dst]"                                           \
+        __asm__ __volatile__(MOVEL " " XM_STR(XM_##xmreg) "(%[ptr]),%[dst]"                                            \
                              : [dst] "=d"(long_value)                                                                  \
                              : [ptr] "a"(xosera_ptr)                                                                   \
                              :);                                                                                       \
@@ -213,7 +221,7 @@ extern volatile xmreg_t * const xosera_ptr;
     ({                                                                                                                 \
         uint16_t word_value;                                                                                           \
         xm_setw(XR_ADDR, xrmem);                                                                                       \
-        __asm__ __volatile__("movep.w " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                           \
+        __asm__ __volatile__(MOVEW " " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                            \
                              : [dst] "=d"(word_value)                                                                  \
                              : [ptr] "a"(xosera_ptr)                                                                   \
                              :);                                                                                       \
@@ -244,7 +252,7 @@ extern volatile xmreg_t * const xosera_ptr;
         (void)(XR_##xreg);                                                                                             \
         uint16_t word_value;                                                                                           \
         xm_setw(XR_ADDR, (XR_##xreg));                                                                                 \
-        __asm__ __volatile__("movep.w " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                           \
+        __asm__ __volatile__(MOVEW " " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                            \
                              : [dst] "=d"(word_value)                                                                  \
                              : [ptr] "a"(xosera_ptr)                                                                   \
                              :);                                                                                       \
@@ -308,7 +316,7 @@ extern volatile xmreg_t * const xosera_ptr;
         uint16_t word_value;                                                                                           \
         xm_setw(XR_ADDR, xrmem);                                                                                       \
         xwait_mem_busy();                                                                                              \
-        __asm__ __volatile__("movep.w " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                           \
+        __asm__ __volatile__(MOVEW " " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                            \
                              : [dst] "=d"(word_value)                                                                  \
                              : [ptr] "a"(xosera_ptr)                                                                   \
                              :);                                                                                       \
@@ -341,7 +349,7 @@ extern volatile xmreg_t * const xosera_ptr;
         uint16_t word_value;                                                                                           \
         xm_setw(XR_ADDR, (XR_##xreg));                                                                                 \
         xwait_mem_busy();                                                                                              \
-        __asm__ __volatile__("movep.w " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                           \
+        __asm__ __volatile__(MOVEW " " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                            \
                              : [dst] "=d"(word_value)                                                                  \
                              : [ptr] "a"(xosera_ptr)                                                                   \
                              :);                                                                                       \

--- a/xosera_m68k_api/xosera_m68k_defs.h
+++ b/xosera_m68k_api/xosera_m68k_defs.h
@@ -24,7 +24,11 @@
 #if !defined(XOSERA_M68K_DEFS_H)
 #define XOSERA_M68K_DEFS_H
 
-#define XM_BASEADDR 0xf80060        // Xosera rosco_m68k register base address
+#ifdef ROSCO_M68K_PRO
+#define XM_BASEADDR 0xff800020      // Xosera rosco_m68k Pro register base address
+#else
+#define XM_BASEADDR 0xf80060        // Xosera rosco_m68k Classic register base address
+#endif
 
 // Xosera XR Memory Regions (size in 16-bit words)
 #define XR_COLOR_ADDR   0x8000        // (R/W) 0x8000-0x81FF 2 x A & B color lookup memory
@@ -45,6 +49,24 @@
 // Xosera Main Registers (XM Registers, directly CPU accessable)
 // NOTE: Main register numbers are multiplied by 4 for rosco_m68k, because of even byte 6800 8-bit addressing plus
 // 16-bit registers
+#ifdef ROSCO_M68K_PRO
+#define XM_XR_ADDR   0x0         // (R /W+) XR register number/address for XM_XR_DATA read/write access
+#define XM_XR_DATA   0x2         // (R /W+) read/write XR register/memory at XM_XR_ADDR (XM_XR_ADDR incr. on write)
+#define XM_RD_INCR   0x4         // (R /W ) increment value for XM_RD_ADDR read from XM_DATA/XM_DATA_2
+#define XM_RD_ADDR   0x6         // (R /W+) VRAM address for reading from VRAM when XM_DATA/XM_DATA_2 is read
+#define XM_WR_INCR   0x8         // (R /W ) increment value for XM_WR_ADDR on write to XM_DATA/XM_DATA_2
+#define XM_WR_ADDR   0xA         // (R /W ) VRAM address for writing to VRAM when XM_DATA/XM_DATA_2 is written
+#define XM_DATA      0xC         // (R+/W+) read/write VRAM word at XM_RD_ADDR/XM_WR_ADDR (and add XM_RD_INCR/XM_WR_INCR)
+#define XM_DATA_2    0xE         // (R+/W+) 2nd XM_DATA(to allow for 32-bit read/write access)
+#define XM_SYS_CTRL  0x10        // (R /W+) busy status, FPGA reconfig, interrupt status/control, write masking
+#define XM_TIMER     0x12        // (R /W+) read 1/10th millisecond timer, write clear interrupt signal
+#define XM_LFSR      0x14        // (RO)    LFSR pseudo-random number // TODO: keep this?
+#define XM_UNUSED_B  0x16        // (R /W ) unused direct register 0xB // TODO: slated for XR_DATA_2 after reorg
+#define XM_RW_INCR   0x18        // (R /W ) XM_RW_ADDR increment value on read/write of XM_RW_DATA/XM_RW_DATA_2
+#define XM_RW_ADDR   0x1A        // (R /W+) read/write address for VRAM access from XM_RW_DATA/XM_RW_DATA_2
+#define XM_RW_DATA   0x1C        // (R+/W+) read/write VRAM word at XM_RW_ADDR (and add XM_RW_INCR)
+#define XM_RW_DATA_2 0x1E        // (R+/W+) 2nd XM_RW_DATA(to allow for 32-bit read/write access)
+#else
 #define XM_XR_ADDR   0x0         // (R /W+) XR register number/address for XM_XR_DATA read/write access
 #define XM_XR_DATA   0x4         // (R /W+) read/write XR register/memory at XM_XR_ADDR (XM_XR_ADDR incr. on write)
 #define XM_RD_INCR   0x8         // (R /W ) increment value for XM_RD_ADDR read from XM_DATA/XM_DATA_2
@@ -61,6 +83,7 @@
 #define XM_RW_ADDR   0x34        // (R /W+) read/write address for VRAM access from XM_RW_DATA/XM_RW_DATA_2
 #define XM_RW_DATA   0x38        // (R+/W+) read/write VRAM word at XM_RW_ADDR (and add XM_RW_INCR)
 #define XM_RW_DATA_2 0x3C        // (R+/W+) 2nd XM_RW_DATA(to allow for 32-bit read/write access)
+#endif
 
 #define SYS_CTRL_MEMWAIT_B  7
 #define SYS_CTRL_BLITBUSY_B 6

--- a/xosera_m68k_api/xosera_m68k_defs.inc
+++ b/xosera_m68k_api/xosera_m68k_defs.inc
@@ -20,11 +20,33 @@
 
 ; See: https://github.com/XarkLabs/Xosera/blob/master/REFERENCE.md
 
+        ifd ROSCO_M68K_PRO
+XM_BASEADDR     equ     $ff800020   ; Xosera rosco_m68k register base address
+        else
 XM_BASEADDR     equ     $f80060     ; Xosera rosco_m68k register base address
+        endif
 
 ; Xosera Main Registers (XM Registers, directly CPU accessable)
 ; NOTE: Main register numbers are multiplied by 4 for rosco_m68k, because of even byte 6800 8-bit addressing plus
 ; 16-bit registers
+        ifd ROSCO_M68K_PRO
+XM_XR_ADDR      equ     $0          ; (R /W+) XR register number/address for XM_XR_DATA read/write access
+XM_XR_DATA      equ     $2          ; (R /W+) read/write XR register/memory at XM_XR_ADDR (XM_XR_ADDR incr. on write)
+XM_RD_INCR      equ     $4          ; (R /W ) increment value for XM_RD_ADDR read from XM_DATA/XM_DATA_2
+XM_RD_ADDR      equ     $6          ; (R /W+) VRAM address for reading from VRAM when XM_DATA/XM_DATA_2 is read
+XM_WR_INCR      equ     $8          ; (R /W ) increment value for XM_WR_ADDR on write to XM_DATA/XM_DATA_2
+XM_WR_ADDR      equ     $A          ; (R /W ) VRAM address for writing to VRAM when XM_DATA/XM_DATA_2 is written
+XM_DATA         equ     $C          ; (R+/W+) read/write VRAM word at XM_RD_ADDR/XM_WR_ADDR (and add XM_RD_INCR/XM_WR_INCR)
+XM_DATA_2       equ     $E          ; (R+/W+) 2nd XM_DATA(to allow for 32-bit read/write access)
+XM_SYS_CTRL     equ     $10         ; (R /W+) busy status, FPGA reconfig, interrupt status/control, write masking
+XM_TIMER        equ     $12         ; (RO   ) read 1/10th millisecond timer [TODO]
+XM_UNUSED_A     equ     $14         ; (R /W ) unused direct register 0xA [TODO]
+XM_UNUSED_B     equ     $16         ; (R /W ) unused direct register 0xB [TODO]
+XM_RW_INCR      equ     $18         ; (R /W ) XM_RW_ADDR increment value on read/write of XM_RW_DATA/XM_RW_DATA_2
+XM_RW_ADDR      equ     $1A         ; (R /W+) read/write address for VRAM access from XM_RW_DATA/XM_RW_DATA_2
+XM_RW_DATA      equ     $1C         ; (R+/W+) read/write VRAM word at XM_RW_ADDR (and add XM_RW_INCR)
+XM_RW_DATA_2    equ     $1E         ; (R+/W+) 2nd XM_RW_DATA(to allow for 32-bit read/write access)
+        else
 XM_XR_ADDR      equ     $0          ; (R /W+) XR register number/address for XM_XR_DATA read/write access
 XM_XR_DATA      equ     $4          ; (R /W+) read/write XR register/memory at XM_XR_ADDR (XM_XR_ADDR incr. on write)
 XM_RD_INCR      equ     $8          ; (R /W ) increment value for XM_RD_ADDR read from XM_DATA/XM_DATA_2
@@ -41,7 +63,7 @@ XM_RW_INCR      equ     $30         ; (R /W ) XM_RW_ADDR increment value on read
 XM_RW_ADDR      equ     $34         ; (R /W+) read/write address for VRAM access from XM_RW_DATA/XM_RW_DATA_2
 XM_RW_DATA      equ     $38         ; (R+/W+) read/write VRAM word at XM_RW_ADDR (and add XM_RW_INCR)
 XM_RW_DATA_2    equ     $3C         ; (R+/W+) 2nd XM_RW_DATA(to allow for 32-bit read/write access)
-
+        endif
 ; XR Extended Register / Region (accessed via XM_XR_ADDR and XM_XR_DATA)
 
 ; XR Memory Regions

--- a/xosera_test_m68k/Makefile
+++ b/xosera_test_m68k/Makefile
@@ -48,6 +48,10 @@ KERMIT=kermit
 SERIAL?=/dev/modem
 BAUD?=9600
 
+ifeq ($(ROSCO_M68K_PRO),true)
+DEFINES+=-DROSCO_M68K_PRO
+endif
+
 # Output config (assume name of directory)
 PROGRAM_BASENAME=$(shell basename $(CURDIR))
 

--- a/xosera_test_m68k/xosera_test_m68k.c
+++ b/xosera_test_m68k/xosera_test_m68k.c
@@ -1851,7 +1851,6 @@ void     xosera_test()
     xmem_setw(XR_COLOR_A_ADDR, 0x0000);        // color # = black
 
     // D'oh! Uses timer    rosco_m68k_CPUMHz();
-
     xr_textmode_pb();
     xr_printf("Xosera Test for rosco_m68k\n");
 

--- a/xosera_vramtest_m68k/Makefile
+++ b/xosera_vramtest_m68k/Makefile
@@ -56,6 +56,10 @@ KERMIT=kermit
 SERIAL?=/dev/modem
 BAUD?=9600
 
+ifeq ($(ROSCO_M68K_PRO),true)
+DEFINES+=-DROSCO_M68K_PRO
+endif
+
 # Output config (assume name of directory)
 PROGRAM_BASENAME=$(shell basename $(CURDIR))
 


### PR DESCRIPTION
## Adds support for rosco_m68k Pro in Xosera API, and updates example code to support building. 

To build for rosco_m68k Pro, pass both `ROSCO_M68K_PRO` options to the `make` command, and specify the `rosco_m68k_pro` repository root as the `ROSCO_M68K_DIR` option. For example (assuming you have the pro repository checked out at `~/rosco_m68k_pro`):

```
ROSCO_M68K_PRO=true ROSCO_M68K_DIR=~/rosco_m68k_pro make clean all
```
